### PR TITLE
fix for selected sessions bug

### DIFF
--- a/aa_engine/aas_getdependencies_bydomain.m
+++ b/aa_engine/aas_getdependencies_bydomain.m
@@ -1,5 +1,5 @@
-% Automatic analysis
-%  Caculatuate dependencies between stages of a different type
+%  Automatic analysis
+%  Calculate dependencies between stages of a different type
 %  Uses aap.directory_conventions.parallel_dependencies tree structure
 %  Parameter 'whattoreturn':
 %   'possiblestreamlocations' (default) - all places where a stream might
@@ -15,27 +15,27 @@
 %  Examples:
 %   pth=aas_getdependencies_bydomain(aap,'study','session',{1,2});  % source stage was at study domain, target stage is at session domain
 %
+% CHANGE HISTORY
+%	OCT2018 [MSJ] -- added selected_sessions to hash (cf. Issue #165), cleanup
+%
 
 function [deps commonind desc]=aas_getdependencies_bydomain(aap, sourcedomain, targetdomain, indices, whattoreturn, modulenum)
 
 if ~exist('modulenum','var')
     modulenum=[];
-end;
+end
 if ~exist('whattoreturn','var')
     whattoreturn='possiblestreamlocations';
-end;
+end
 
-
-[hit resp]=aas_cache_get(aap,mfilename,sourcedomain,targetdomain,indices,whattoreturn,modulenum);
-% disable non-exact in/outputs
-% hit=false;
+selected_sessions = aap.acq_details.selected_sessions;
+[hit resp]=aas_cache_get(aap,mfilename,sourcedomain,targetdomain,selected_sessions,indices,whattoreturn,modulenum);
 
 if (~hit)
     % Cache miss, but actually only indices in domain tree relevant to the
     % common point of the source & target trees can affect the response
     %
     % So, find that common point and then retry the cache
-    
     targetdomaintree=aas_dependencytree_finddomain(targetdomain,aap.directory_conventions.parallel_dependencies,{});
     sourcedomaintree=aas_dependencytree_finddomain(sourcedomain,aap.directory_conventions.parallel_dependencies,{});
     % Find the point where the source and target branches converge
@@ -44,18 +44,9 @@ if (~hit)
         if ~strcmp(targetdomaintree{commonind},sourcedomaintree{commonind})
             commonind=commonind-1;
             break
-        end;
-    end;
-    
-    
-% disable non-exact in/outputs
-%     if (commonind<length(targetdomaintree))
-%         cacheindices=indices(1:(commonind)); % CW hacky fix - indices(1:(commonind-1));
-%         [hit resp]=aas_cache_get(aap,mfilename,sourcedomain,targetdomaintree{commonind},cacheindices,whattoreturn,modulenum);
-%     else
-%         cacheindices=indices;
-%     end;
-end;
+		end
+	end
+end
 
 if (hit)
     deps=resp{1};
@@ -64,8 +55,7 @@ else
     
     if length(indices)~=(length(targetdomaintree)-1)
         aas_log(aap,true,sprintf('Expected %d indicies for domain "%s" but got %d',length(targetdomaintree)-1,targetdomain,length(indices)));
-    end;
-    
+	end
     
     switch(whattoreturn)
         case 'possiblestreamlocations'
@@ -82,14 +72,14 @@ else
             onlyreportdomain=sourcedomain;
         otherwise
             aas_log(aap,true,sprintf('Unknown dependency calculation requested of %s',whattoreturn));
-    end;
+	end
     
     deps={};
     tree=aap.directory_conventions.parallel_dependencies;
     targetInd = length(targetdomaintree);
+	
     % CASE 1: same branch, source module higher up
     if commonind==length(sourcedomaintree)
-        
         if strcmp(whattoreturn,'possiblestreamlocations')
             % Bit from source to one above target
             for nodeind=commonind:targetInd
@@ -101,17 +91,17 @@ else
             % Target and everything below
             for nodeind=1:targetInd
                 tree=tree.(targetdomaintree{nodeind});
-            end;
+			end
             deps=[deps aas_dependencytree_findbranches(aap,{tree,targetdomaintree,indices},indices,onlyreportdomain,module,{},sourcedomain,hasancestory)];
         else
             deps{end+1}={sourcedomain,indices(1:length(sourcedomaintree)-1)};
-        end;
+		end
         % CASE 2: same branch, target module higher up
     elseif commonind==length(targetdomaintree)
         % Source and everything below
         for nodeind=1:targetInd
             tree=tree.(sourcedomaintree{nodeind});
-        end;
+		end
         deps=[aas_dependencytree_findbranches(aap,{tree,targetdomaintree,indices},indices,onlyreportdomain,module,{},sourcedomain,hasancestory)];
         % CASE 3: different branches
     else
@@ -120,30 +110,22 @@ else
         tree=aap.directory_conventions.parallel_dependencies;
         for nodeind=1:commonind
             tree=tree.(sourcedomaintree{nodeind});
-        end;
+		end
         % Only pick items on or below sourcedomain
         hasancestory=false;
         deps=[aas_dependencytree_findbranches(aap,{tree,sourcedomaintree(1:commonind-1),indices(1:commonind-1)},indices(1:commonind-1),onlyreportdomain,module,{},sourcedomain,hasancestory)];
-    end;
+	end
     
-    aas_cache_put(aap,mfilename,{deps commonind},sourcedomain,targetdomain,indices,whattoreturn,modulenum);
-% disable non-exact in/outputs
-%     aas_cache_put(aap,mfilename,{deps commonind},sourcedomain,targetdomaintree{commonind},cacheindices,whattoreturn,modulenum); % also store in the cache indexed by the truncated portion
-    
-end;
+    aas_cache_put(aap,mfilename,{deps commonind},sourcedomain,targetdomain,selected_sessions,indices,whattoreturn, modulenum);
+	    
+end
 
 %% And report
 if nargout==3
     desc='';
     for depind=1:length(deps)
         desc=[desc deps{depind}{1} '[ ' sprintf('%d ',deps{depind}{2}) '] '];
-    end;
-end;
+	end
 end
 
-
-
-
-
-
-
+end


### PR DESCRIPTION
Changed aas_getdependencies_bydomain to include selected session when generating the cache hash. Also did some minor cleanup. There was a question last skype whether this will play nice when connecting pipelilnes. Testing should focus on that.