### PR TITLE
code changes to handle single-file dicom and a new TR/TE header field

### DIFF
--- a/aa_engine/aas_convertseries_fromstream.m
+++ b/aa_engine/aas_convertseries_fromstream.m
@@ -217,6 +217,20 @@ for subdirind=1:length(subdirs)
             infoD.slicetimes = slicetimes/1000;
             infoD.echospacing = echospacing;
             
+            % sanity check: some aa modules assume fieldnames
+            % RepetitionTime and EchoTime exist in the DICOM header 
+            % which might not if they were defined by private
+            % fields -- create them now if need be (note also
+            % these are in milliseconds not seconds)
+            
+            if (~isfield(infoD,'EchoTime'))
+                infoD.EchoTime = TE;
+            end
+            
+            if (~isfield(infoD,'RepetitionTime'))
+                infoD.RepetitionTime = TR;
+            end		
+            
             if isfield(infoD,'SliceLocation')
                 
                 % Single slice per DICOM:

--- a/aa_engine/aas_getsetting.m
+++ b/aa_engine/aas_getsetting.m
@@ -23,7 +23,10 @@ if ~isempty(val) && (nargin == 3) % index
     
     try val = val{index};
     catch
-        aas_log(aap,false,sprintf('WARNING: Setting <%s> has fewer then %d elements.\nWARNING: First value will be applied!',settingstring,index));
+        dbs = dbstack(1);
+        aas_log(aap,false,sprintf('WARNING (%s): %s requested %s(%d), but', mfilename, dbs(1).name, settingstring, index));
+        aas_log(aap,false,sprintf('WARNING (%s): only %d value(s) are defined in the current settings.', mfilename, numel(val)));
+        aas_log(aap,false,sprintf('WARNING (%s): The first value (%0.9g) will be returned instead.', mfilename, val{1}));
         val = val{1};
     end
 end

--- a/aa_modules/aamod_convert_epis.m
+++ b/aa_modules/aamod_convert_epis.m
@@ -421,7 +421,7 @@ switch task
             [aap fns DICOMHEADERS]=aas_convertseries_fromstream(aap,domain,indices,'dicom_epi');
             			
 			if ~isempty(aas_getsetting(aap,'ignoreafter'))
-				fns = fns(1:min(numel(fns),aas_getsetting(aap,'ignoreafter')));
+				fns = fns(1:min(numel(fns),aas_getsetting(aap,'ignoreafter',sess)));
 			end
             
             finalepis=fns;

--- a/aa_modules/aamod_convert_epis.xml
+++ b/aa_modules/aamod_convert_epis.xml
@@ -15,6 +15,10 @@
             </echoweightmethod>
                 
             <outputstats>1</outputstats>  <!-- output noise estimates and so on? -->
+
+            <!-- ignoreafter can be a vector (one value for each session) -->
+            <!-- if scalar, the value will be applied to all sessions -->
+            <!-- (and this may generate a warning during execution) -->
             
             <ignoreafter desc='Only take this many volume (including dummies)'>9999999</ignoreafter>            
 


### PR DESCRIPTION
See #178 

There are 2 changed files in this PR: 

aamod_convert_epis.m
aas_convertseries_fromstream.m

This includes Tibor's fix mentioned in the Issue, but also more code changes to address the followup problem I reported.  The changes aren't extensive -- the new lines may even be indented uniquely to make them stand out. (I wish I could say I did that on purpose, but it's really that with the Matlab editor, vi, and github all treating indentation differently, I find it's impossible to format code consistently.)

I can't be sure this is a solid fix --- I only have two kinds of dicom I can test. All I can say is it fixed the problem I reported and didn't break anything new.
