### PR TITLE
Small fix - aas_getsourcestage

### DIFF
--- a/aa_engine/aas_getsourcestage.m
+++ b/aa_engine/aas_getsourcestage.m
@@ -7,9 +7,9 @@ if nargin == 2 % based on branch
     currbranch = aap.tasklist.currenttask.extraparameters.aap.directory_conventions.analysisid_suffix;
     for currmodnum = find(strcmp({aap.tasklist.main.module.name}, sourcemod))
         srcbranch = aap.tasklist.main.module(currmodnum).extraparameters.aap.directory_conventions.analysisid_suffix;
-        if strcmp(currbranch,srcbranch), break; end
+        if strcmp(currbranch,srcbranch) || contains(currbranch,[srcbranch '_']), break; end % might be an issue if one branchname contains the other
     end
-    if ~strcmp(currbranch,srcbranch), currmodnum = aap.tasklist.currenttask.modulenumber; end
+    if ~strcmp(currbranch,srcbranch) && ~contains(currbranch,[srcbranch '_']), currmodnum = aap.tasklist.currenttask.modulenumber; end
     
 else % based on stream
     stream = strsplit(stream,'.');


### PR DESCRIPTION
This PR is a small fix for aas_getsourcestage with branched tasklists.

It has one (plausible) caveat that one branchname MUST NOT contain the other + '_', which would not be good for readability anyway.