### PR TITLE
Fix aas_checkpath allowcolon input effect

### DIFF
--- a/aa_engine/aas_checkpath.m
+++ b/aa_engine/aas_checkpath.m
@@ -17,15 +17,15 @@ if (isempty(pth))
 else
     if (allowwildcards)
         if allowcolon
-            matches=regexp(pth,'[-*?\w/.\_]*','match');
-        else
             matches=regexp(pth,'[-*?\w/.\_:]*','match');
+        else
+            matches=regexp(pth,'[-*?\w/.\_]*','match');
         end;
     else
         if allowcolon
             matches=regexp(pth,'[-\w/.\_:]*','match');
         else
-            matches=regexp(pth,'[-\w/.\_:]*','match');
+            matches=regexp(pth,'[-\w/.\_]*','match');
         end;
     end;
     


### PR DESCRIPTION
With wildcards, colon is now allowed when allowcolon is true, instead of when allowcolon is false

Without wildcards, colon is now only allowed when allowcolon is actually true

Closes #267 