### PR TITLE
tidy aamod_coreg_extended_2_epi.xml

### DIFF
--- a/aa_modules/aamod_coreg_extended_2_epi.xml
+++ b/aa_modules/aamod_coreg_extended_2_epi.xml
@@ -18,10 +18,10 @@
             
             <inputstreams>
                 <stream>t1totemplate_xfm</stream>
-                <stream diagnostic='1'>aamod_coreg_extended_1_00001.structural</stream>  
-                <stream isessential='0'>wholebrain_epi</stream>
-				<stream diagnostic='1'>meanepi</stream>              
                 <stream>epi</stream>
+                <stream isessential='0'>wholebrain_epi</stream>
+                <stream diagnostic='1'>aamod_coreg_extended_1_00001.structural</stream>  
+                <stream diagnostic='1'>meanepi</stream>              
             </inputstreams>
             
             <outputstreams>
@@ -30,4 +30,3 @@
         </currenttask>
     </tasklist>
 </aap>
-

--- a/aa_parametersets/aap_parameters_defaults_CBSU.xml
+++ b/aa_parametersets/aap_parameters_defaults_CBSU.xml
@@ -48,6 +48,10 @@
                     <templateDir>/imaging/local/software/workbench/templates</templateDir>
                 </extraparameters>
             </toolbox>
+            <toolbox desc='Toolbox with implemented interface in extrafunctions/toolboxes' ui='custom'>
+              <name desc='Name corresponding to the name of the interface without the "Class" suffix' ui='text'>bwt</name>
+              <dir ui='dir'>/imaging/local/software/BrainWavelet</dir>
+            </toolbox>
             <linuxshell desc='Linux shell used to run linux commands' ui='text'>bash</linuxshell>
             <fsldir desc='Path to fsl' ui='dir'>/imaging/local/software/fsl/v5.0.11/x86_64/fsl</fsldir>
             <fslsetup desc='Path to fsl setup script, executing before any fsl command' ui='text'>/imaging/local/linux/config/fsl_csh v5.0.11</fslsetup>


### PR DESCRIPTION
_Edited_ Small pull request that suggests:
1. tidy minor syntax (i.e., indents & argument order to match original aamodule). https://github.com/automaticanalysis/automaticanalysis/pull/283/commits/e73a46b9d3f785f4d5dc49c6748deab72d3e860b
(This was something I noticed and quickly updated when debugging an old pipeline I that had used modules which are now renamed) 
2. Update CBSU parameter set to include the brainWavelet toolbox, according to the newer toolbox class method. https://github.com/automaticanalysis/automaticanalysis/pull/283/commits/3245d40881230505c4e524c66e3e1f39ab1a32aa