### PR TITLE
Fixes to be able to run example helloworld on windows

### DIFF
--- a/aa_engine/aa_doprocessing.m
+++ b/aa_engine/aa_doprocessing.m
@@ -283,7 +283,9 @@ for mytasks = {'checkrequirements','doit'} %
             msg='';
             alldone=true;
             doneflag=aas_doneflag_getpath_bydomain(aap,domain,indices,k);
-            
+            % When used in aas_log messages, escape backward slashes from windows paths.
+            logsafe_path = strrep(doneflag, '\', '\\');
+
             % Check whether tasksettings have changed since the last execution,
             % and if they have, then delete doneflag to trigger re-execution
             if strcmp(task,'doit') && isfield(aap.options,'checktasksettingconsistency') && aap.options.checktasksettingconsistency && aas_doneflagexists(aap,doneflag)
@@ -297,7 +299,7 @@ for mytasks = {'checkrequirements','doit'} %
             end
 
             if aas_doneflagexists(aap,doneflag) && strcmp(task,'doit')
-                msg=[msg sprintf('- done: %s for %s \n',description,doneflag)];
+                msg=[msg sprintf('- done: %s for %s \n',description,logsafe_path)];
             else
                 alldone=false;
                 switch (task)
@@ -329,7 +331,7 @@ for mytasks = {'checkrequirements','doit'} %
                         taskmask.tobecompletedfirst=tbcf;
 
                         % now queue current stage
-                        aas_log(aap,0,sprintf('MODULE %s PENDING: %s for %s',stagename,description,doneflag));
+                        aas_log(aap,0,sprintf('MODULE %s PENDING: %s for %s',stagename,description,logsafe_path));
 
                         taskmask.indices=indices;
                         taskmask.doneflag=doneflag;

--- a/aa_engine/aa_doprocessing_onetask.m
+++ b/aa_engine/aa_doprocessing_onetask.m
@@ -63,7 +63,9 @@ aaworker.outputstreams=[];
 
 % Now execute the module, and change the 'done' flags if task='doit'
 
-[doneflag doneflagpath stagetag]=aas_doneflag_getpath_bydomain(aap,domain,indices,modulenum);
+[doneflag, doneflagpath, stagetag]=aas_doneflag_getpath_bydomain(aap,domain,indices,modulenum);
+% When used in aas_log messages, escape backward slashes from windows paths.
+logsafe_path = strrep(doneflagpath, '\', '\\');
 outputpath=aas_getpath_bydomain(aap,domain,indices);
 aas_makedir(aap,outputpath);
 aap_tmp=aap;
@@ -72,7 +74,7 @@ save(fullfile(outputpath,sprintf('aap_parameters_%s.mat',stagetag)),'aap');
 aap=aap_tmp;
 if (aas_doneflagexists(aap,doneflag))
     if (strcmp(task,'doit'))
-        aas_log(aap,0,sprintf('- completed previously: %s for %s',description,doneflagpath),aap.gui_controls.colours.completedpreviously);
+        aas_log(aap,0,sprintf('- completed previously: %s for %s',description,logsafe_path),aap.gui_controls.colours.completedpreviously);
         %                 re-write done flag as it clears dependencies
         aas_writedoneflag(aap,doneflag);
     end
@@ -92,7 +94,7 @@ else
                 aas_delete_doneflag_bydomain(aap,aap.internal.outputstreamdestinations{modulenum}.stream(k0i).destnumber,domain,indices);
             end
             % now run current stage
-            aas_log(aap,0,sprintf('MODULE %s RUNNING: %s for %s',stagename,description,doneflagpath),aap.gui_controls.colours.running);
+            aas_log(aap,0,sprintf('MODULE %s RUNNING: %s for %s',stagename,description,logsafe_path),aap.gui_controls.colours.running);
 
             % ...fetch inputs
             if ~isempty(aap.internal.inputstreamsources{modulenum})

--- a/aa_engine/aa_doprocessing_onetask.m
+++ b/aa_engine/aa_doprocessing_onetask.m
@@ -205,7 +205,7 @@ if (tempdirtodelete)
     % error, so cd
     [s, ~]=aas_shell('pwd');
     if (s)
-        cd ~
+        cd(getenv('HOME'))
     end
 end
 

--- a/aa_engine/aa_doprocessing_onetask.m
+++ b/aa_engine/aa_doprocessing_onetask.m
@@ -6,11 +6,11 @@ if nargin == 5 % aaworker passed
     aaworker = gaaworker;
 end
 if isfield(aaworker,'aacache')
-   aacache = aaworker.aacache; 
+    aacache = aaworker.aacache;
 end
 
 aaworker.modulestarttime=now;
-    
+
 if aap.options.timelog
     tic
 end
@@ -28,27 +28,27 @@ else
 end
 
 if (~strcmp(aap.directory_conventions.remotefilesystem,'none'))
-    [pth nme ext]=fileparts(tempname);
+    [~, nme, ~]=fileparts(tempname);
     tempdirtodelete=[datestr(now,30) '_' nme];
-    [s w]=system('whoami');
+    [s, w]=system('whoami');
     tempdirtodelete=fullfile('/cn_data',deblank(w),tempdirtodelete);
     aap.acq_details.root=fullfile(tempdirtodelete,aap.acq_details.root);
 else
     tempdirtodelete=[];
-end;
+end
 
 studypath=aas_getstudypath(aap);
 aap=aas_makedir(aap,studypath);
 
 % allow full path of module to be provided
-[stagepath stagename]=fileparts(aap.tasklist.main.module(modulenum).name);
+[~, stagename]=fileparts(aap.tasklist.main.module(modulenum).name);
 index=aap.tasklist.main.module(modulenum).index;
 
 if (isfield(aap.schema.tasksettings.(stagename)(index).ATTRIBUTE,'mfile_alias'))
     mfile_alias=aap.schema.tasksettings.(stagename)(index).ATTRIBUTE.mfile_alias;
 else
     mfile_alias=stagename;
-end;
+end
 
 taskSchema = aap.schema.tasksettings.(stagename)(index);
 
@@ -75,35 +75,35 @@ if (aas_doneflagexists(aap,doneflag))
         aas_log(aap,0,sprintf('- completed previously: %s for %s',description,doneflagpath),aap.gui_controls.colours.completedpreviously);
         %                 re-write done flag as it clears dependencies
         aas_writedoneflag(aap,doneflag);
-    end;
+    end
 else
     switch (task)
         case 'checkrequirements'
             [aap,resp]=aa_feval_withindices(mfile_alias,aap,task,indices);
-            
+
             if (length(resp)>0)
                 aas_log(aap,0,['\n***WARNING: ' resp]);
-            end;
+            end
         case 'doit'
             tic
             % before starting current stage, delete done_
             % flag for stages that are dependencies of it
             for k0i=1:length(aap.internal.outputstreamdestinations{modulenum}.stream)
                 aas_delete_doneflag_bydomain(aap,aap.internal.outputstreamdestinations{modulenum}.stream(k0i).destnumber,domain,indices);
-            end;
+            end
             % now run current stage
             aas_log(aap,0,sprintf('MODULE %s RUNNING: %s for %s',stagename,description,doneflagpath),aap.gui_controls.colours.running);
-            
+
             % ...fetch inputs
             if ~isempty(aap.internal.inputstreamsources{modulenum})
-                
+
                 allinputs={};
                 streamfiles=cell(length(aap.internal.inputstreamsources{modulenum}.stream),1);
                 for inpind=1:length(aap.internal.inputstreamsources{modulenum}.stream)
-                    
+
                     inp=aap.internal.inputstreamsources{modulenum}.stream(inpind);
-                    
-                    % There might be additional settings for this input 
+
+                    % There might be additional settings for this input
                     % Added by CW to allow domain override
                     if iscell(taskSchema.inputstreams.stream)  && ...
                             ~(numel(taskSchema.inputstreams.stream) == 1 && isstruct(taskSchema.inputstreams.stream{1}))
@@ -118,21 +118,21 @@ else
                     searchIndices = indices;    % Default to domain indices
                     if isstruct(inputSchema) && isfield(inputSchema.ATTRIBUTE,'forcedomain')
                         searchDomain = inputSchema.ATTRIBUTE.forcedomain;
-                        
+
                         % The current 'indices' specify the current module,
                         % we have to update them to reflect the new
                         % (forced) search domain.
                         searchDomainTree = aas_dependencytree_finddomain(searchDomain,aap.directory_conventions.parallel_dependencies,{});
                         moduleDomainTree = aas_dependencytree_finddomain(domain,aap.directory_conventions.parallel_dependencies,{});
-                        
+
                         if length(searchDomainTree) < length(moduleDomainTree)
                             searchIndices = searchIndices(1:length(searchDomainTree)-1);
                         else
                             aas_log(aap, 1, 'NYI: forcing domain to be more specific, we have to have a way to specify the new indices.');
                         end
-   
+
                     end
-                    
+
                     deps=aas_getdependencies_bydomain(aap,inp.sourcedomain,searchDomain,searchIndices);
                     % check whether the input module(s) has/have been skipped
                     skipped = true(1,numel(deps));
@@ -167,30 +167,30 @@ else
                         aas_writedoneflag(aap,doneflag,'skipped');
                         return
                     end
-                    
+
                     [gotinputs, streamfiles{inpind}]=aas_retrieve_inputs_part1(aap,inp,allinputs,deps);
                     if isempty(setdiff(gotinputs,allinputs)) && inp.isessential % no new inputs found
                         aas_log(aap,true,sprintf('No inputs obtained for stream %s!\n\tModule %s might not have created it.',inp.name,inp.sourcestagename));
-                    end;
-                    allinputs=[allinputs;gotinputs];
-                end;
-                
+                    end
+                    allinputs = [allinputs; gotinputs];
+                end
+
                 % Actually copy the data files
-                % This is now done separately to allow for asynchronous retrieval of all of the streams together, where they've  
+                % This is now done separately to allow for asynchronous retrieval of all of the streams together, where they've
                 % gone of too S3 or Glacier archive
                 for inpind=1:length(aap.internal.inputstreamsources{modulenum}.stream)
                     aap=aas_retrieve_inputs_part2(aap,streamfiles{inpind});
-                end;
-            end;
-            
-            
+                end
+            end
+
+
             % ...and actually run
             aas_log(aap,false,' executing',aap.gui_controls.colours.executing);
-            [aap,resp]=aa_feval_withindices(mfile_alias,aap,task,indices);
+            [aap,~]=aa_feval_withindices(mfile_alias,aap,task,indices);
             aas_writedoneflag(aap,doneflag);
-            aas_log(aap,0,sprintf('MODULE %s COMPLETED',stagename),aap.gui_controls.colours.completed);            
-    end;
-end;
+            aas_log(aap,0,sprintf('MODULE %s COMPLETED',stagename),aap.gui_controls.colours.completed);
+    end
+end
 close_task(aap,tempdirtodelete);
 end
 
@@ -201,11 +201,11 @@ if (tempdirtodelete)
     rmdir(tempdirtodelete,'s');
     % If the directory was changed into this path we'll now get a shell
     % error, so cd
-    [s w]=aas_shell('pwd');
+    [s, ~]=aas_shell('pwd');
     if (s)
         cd ~
-    end;
-end;
+    end
+end
 
 if aap.options.timelog
     aas_time_elapsed

--- a/aa_engine/aas_checkpath.m
+++ b/aa_engine/aas_checkpath.m
@@ -1,40 +1,47 @@
 % Assert that input pth (with fieldname nme) does not contain forbidden
 % characters. Called by aas_validatepaths.
 %
-% [aap passed]=aas_checkpath(aap,pth,nme,allowwildcards,allowcolon)
-function [aap passed]=aas_checkpath(aap,pth,nme,allowwildcards,allowcolon)
+% [aap, passed] = aas_checkpath(aap, pth, nme, allowwildcards, allowpathsep)
+function [aap, passed] = aas_checkpath(aap, pth, nme, allowwildcards, allowpathsep)
 
-if ~exist('allowwildcards','var') || isempty(allowwildcards)
-    allowwildcards=false;
-end;
+passed = true;
 
-if ~exist('allowcolon','var') || isempty(allowcolon)
-    allowcolon=false;
-end;
+if isempty(pth)
+    return
+end
 
-if (isempty(pth))
-    passed=true;
+% Save original pth input for use in log message
+% When used in aas_log messages, escape backward slashes from windows paths.
+logsafe_path = strrep(pth, '\', '\\');
+
+allowedchars = '-\w/.\_';
+if exist('allowwildcards','var') && ~isempty(allowwildcards) && allowwildcards
+    allowedchars = [allowedchars, '*?'];
+end
+
+if ispc()
+    % On windows:
+    % - paths can start with a drive letter followed by a : when it is an absolute path
+    % - paths natively have a \ as filesep (though can also have /)
+    expression = ['([A-Z]:)?[\\', allowedchars, ']*'];
 else
-    if (allowwildcards)
-        if allowcolon
-            matches=regexp(pth,'[-*?\w/.\_:]*','match');
-        else
-            matches=regexp(pth,'[-*?\w/.\_]*','match');
-        end;
-    else
-        if allowcolon
-            matches=regexp(pth,'[-\w/.\_:]*','match');
-        else
-            matches=regexp(pth,'[-\w/.\_]*','match');
-        end;
-    end;
-    
-    if (length(matches)==1) && (strcmp(matches{1},pth))
-        passed=true;
-    else
-        passed=false;
-        % When used in aas_log messages, escape backward slashes from windows paths.
-        logsafe_path = strrep(pth, '\', '\\');
-        aas_log(aap,true,sprintf('Paths in aa can only contain the characters a-z, A-Z, 0-9, _, -, ., / and sometimes wildcards/colons \nYour path %s=''%s'' does not satisfy this.',nme,logsafe_path));
+    expression = ['[', allowedchars, ']*'];
+end
+
+if exist('allowpathsep','var') && ~isempty(allowpathsep) && allowpathsep
+    pths = strsplit(pth, pathsep);
+else
+    pths = {pth};
+end
+
+for i = 1:length(pths)
+    checkpath = pths{i};
+    matches = regexp(checkpath, expression, 'match');
+    if length(matches)~=1 || ~(strcmp(matches{1},checkpath))
+        passed = false;
+        msg = sprintf('Paths in aa can only contain the characters a-z, A-Z, 0-9, _, -, ., / and sometimes wildcards/colons \nYour path %s=''%s'' does not satisfy this.',nme,logsafe_path);
+        aas_log(aap, true, msg);
     end
+end
+
 end

--- a/aa_engine/aas_checkpath.m
+++ b/aa_engine/aas_checkpath.m
@@ -33,6 +33,8 @@ else
         passed=true;
     else
         passed=false;
-        aas_log(aap,true,sprintf('Paths in aa can only contain the characters a-z, A-Z, 0-9, _, -, ., / and sometimes wildcards/colons \nYour path %s=''%s'' does not satisfy this.',nme,pth));
-    end;
+        % When used in aas_log messages, escape backward slashes from windows paths.
+        logsafe_path = strrep(pth, '\', '\\');
+        aas_log(aap,true,sprintf('Paths in aa can only contain the characters a-z, A-Z, 0-9, _, -, ., / and sometimes wildcards/colons \nYour path %s=''%s'' does not satisfy this.',nme,logsafe_path));
+    end
 end

--- a/aa_engine/aas_desc_outputs.m
+++ b/aa_engine/aas_desc_outputs.m
@@ -70,7 +70,7 @@ descriptor=fullfile(localroot,streamnme);
 trimmedoutputs=cell(1,osd.numoutputs);
 for d=1:osd.numoutputs
     fle=outputs(d,:);
-    if fle(1) == '/' % absolut path
+    if is_absolute_path(fle)
         fle = readlink(fle); % make sure that the path is canonical
         if (length(fle)>length(localroot) && strcmp(fle(1:length(localroot)),localroot))
             fle=fle(length(localroot)+1:end);

--- a/aa_engine/aas_desc_outputs.m
+++ b/aa_engine/aas_desc_outputs.m
@@ -1,13 +1,13 @@
-% aa describe files that form an output stream 
+% aa describe files that form an output stream
 % Preferred new syntax:
 %  function [aap]=aas_desc_outputs(aap,domain,indices,streamname,outputs)
-%  e.g., 
+%  e.g.,
 %   aas_desc_outputs(aap,'subject',[1],'epi',fns)
 %   aas_desc_outputs(aap,'session',[1,1],'epi',fns)
 %   aas_desc_outputs(aap,'searchlight',[4,2,77],'epi',fns)
 %     [subject 4, session 2, searchligh 77]
 %
-% Old syntax (still alllowed): 
+% Old syntax (still alllowed):
 %  function [aap]=aas_desc_outputs(aap,[subject,[session]],streamname,outputs)
 % Outputs may either be specified using a relative or absolute path. If the
 % latter, the path is trimmed to make it relative.
@@ -20,7 +20,7 @@ osd=[];
 
 streamname=varargin{end-1};
 if isstruct(streamname), streamname = streamname.CONTENT; end
-    
+
 pos=find(streamname=='.');
 if (~isempty(pos))
     streamname=streamname(pos(end)+1:end);
@@ -39,7 +39,7 @@ switch(nargin)
     case 4
         i=varargin{1};
         localroot=aas_getsubjpath(aap,i);
-        [pth, nme, ext]=fileparts(localroot);
+        [~, nme, ext]=fileparts(localroot);
         streamdesc=sprintf(' %s ',[nme ext]);
     case 5
         if ischar(varargin{1})
@@ -50,7 +50,7 @@ switch(nargin)
             j=varargin{2};
             localroot=aas_getsesspath(aap,i,j);
             [pth, nme1, ext1]=fileparts(localroot);
-            [pth, nme2, ext2]=fileparts(pth);
+            [~, nme2, ext2]=fileparts(pth);
             streamdesc=sprintf(' %s %s ',[nme2 ext2],[nme1 ext1]);
         end
 end
@@ -64,12 +64,11 @@ if iscell(outputs), outputs=char(outputs); end
 
 osd.numoutputs=size(outputs,1);
 
-
 descriptor=fullfile(localroot,streamnme);
 
 % Trim absolute path if it has been provided
-trimmedoutputs={};
-for d=1:size(outputs,1)
+trimmedoutputs=cell(1,osd.numoutputs);
+for d=1:osd.numoutputs
     fle=outputs(d,:);
     if fle(1) == '/' % absolut path
         fle = readlink(fle); % make sure that the path is canonical
@@ -126,10 +125,10 @@ switch(aap.directory_conventions.remotefilesystem)
         % Now write to [user]_streams domain
         attr.numfiles=size(outputs,1);
         attr.md5_base64=md5_base64;
-        
+
         streamentry=[aaworker.bucket '|' s3root '/' streamnme];
         sdb_put_attributes(aap,aaworker.streamtablename,streamentry,attr);
-        
+
         aas_log(aap,false,sprintf('Written sdb to %s called %s',aaworker.streamtablename,streamentry));
 
         osd.s3root=s3root;

--- a/aa_engine/aas_expandpathbyvars.m
+++ b/aa_engine/aas_expandpathbyvars.m
@@ -18,6 +18,12 @@
 % xnew = aas_expandpathbyvars(x, [verbose=false])
 function x = aas_expandpathbyvars(x, verbose)
 
+if ispc()
+    % Not supported yet for windows
+    % See issues #288 and #289
+    return
+end
+
 if ~exist('verbose','var') || isempty(verbose)
     verbose = false;
 end

--- a/aa_engine/aas_shell.m
+++ b/aa_engine/aas_shell.m
@@ -17,14 +17,18 @@ if ~hit
         wshell=wshell(pos(end)+1:end);
     end
     wshell=strtrim(wshell);
-    
+
     % stops colours
     if (strcmp(wshell,'bash') || strcmp(wshell,'sh'))
         prefix='export TERM=dumb;';
+    elseif ispc()
+        % TBD: Color suppression needed on Windows? And how to? For now,
+        % just keep empty.
+        prefix='';
     else
         prefix='setenv TERM dumb;';
     end
-    
+
     % cache back
     aas_cache_put([],'shellprefix',prefix);
 end

--- a/developer/aa_test_inittest.m
+++ b/developer/aa_test_inittest.m
@@ -15,12 +15,12 @@ end
 
 temp = strsplit(testpath,filesep); temp = strsplit(temp{end},'_');
 aap.directory_conventions.analysisid = [ temp{2} '_' temp{3} ];
-if contains(aap.directory_conventions.rawdatadir,':') % more then one directories
-    demodir = regexp(aap.directory_conventions.rawdatadir,'(?<=:)[a-zA-Z0-9_\/]*aa_demo(?:)','match');
-else % one directory
-    demodir = regexp(aap.directory_conventions.rawdatadir,'[a-zA-Z0-9_\/]*aa_demo(?:)','match');
+rawdatadirs = strsplit(aap.directory_conventions.rawdatadir, pathsep)';
+demoind = cell_index(rawdatadirs, 'aa_demo');
+if demoind==0
+    aas_log([],true,'aap.directory_conventions.rawdatadir contains no aa_demo directory');
 end
-if isempty(demodir), aas_log([],true,'aap.directory_conventions.rawdatadir contains no aa_demo directory'); end   
+demodir = regexp(rawdatadirs{demoind(1)},'[a-zA-Z0-9_\/.]*aa_demo','match');
 aap.directory_conventions.rawdatadir = fullfile(demodir{1},temp{2});
 
 anadir = fullfile(aap.acq_details.root, aap.directory_conventions.analysisid);
@@ -28,7 +28,7 @@ fprintf('Saving results in: %s\n', anadir);
 if exist(anadir,'dir') && deleteprevious
     fprintf('Removing previous results...');
     rmdir(anadir,'s');
-    fprintf('Done\n');    
+    fprintf('Done\n');
 end
 
 aap.options.wheretoprocess = wheretoprocess;

--- a/extrafunctions/is_absolute_path.m
+++ b/extrafunctions/is_absolute_path.m
@@ -1,0 +1,22 @@
+function is_absolute = is_absolute_path(fpath)
+% is_absolute = is_absolute_path(fpath)
+% Return boolean whether input fpath is an absolute path
+
+% make sure fileseperators are right
+fpath = fullfile(fpath, '');
+
+% check if path is absolute
+is_absolute = true;
+if ispc()
+    if length(fpath) < 2 || (fpath(2) ~= ':' && ~strcmpi(repmat(filesep,1,2), fpath(1:2)))
+        is_absolute = false;
+    end
+elseif isunix()
+    if ~(fpath(1) == filesep || fpath(1) == '~')
+        is_absolute = false;
+    end
+else
+    error('Unsupported operating system');
+end
+
+end


### PR DESCRIPTION
Still requires that the variables in aa_example_helloworld.m itself are set to correct windows paths, and of course to have a parameter file with the correct paths.

Fix #266 
Fix #277 
Fix #278 
Fix #284 
Fix #290 
Changes for #264 
Changes for #276 
Changes for #279
Related to #288 and #289


