### PR TITLE
ENH: Adapt aa_test to use matlab unittest framework

### DIFF
--- a/developer/aa_test.m
+++ b/developer/aa_test.m
@@ -78,17 +78,6 @@ argParse.addParameter('wheretoprocess','localsingle', @ischar);
 argParse.addParameter('parameterfile','', @ischar);
 argParse.parse(varargin{:});
 
-% parse glob negation tilde
-globflag = 0;
-glob = argParse.Results.glob;
-if ~isempty(glob)
-    globflag = 1;
-    if startsWith(glob,'~')
-        globflag = -1;
-        glob = glob(2:end);
-    end
-end
-
 % logging
 logfile = fullfile(pwd,'aa_test.log');
 if exist(logfile,'file')
@@ -110,12 +99,21 @@ suiteUseCases = matlab.unittest.TestSuite.fromClass(?testUseCases);
 % PLACEHOLDER: Here, get the non-use case tests
 
 %% Apply glob-based filtering
-constr = matlab.unittest.constraints.ContainsSubstring(glob);
-select = matlab.unittest.selectors.HasName(constr);
-if globflag < 0
-    suiteUseCases = suiteUseCases.selectIf(~select);
-elseif globflag > 0
-    suiteUseCases = suiteUseCases.selectIf(select);
+glob = argParse.Results.glob;
+if ~isempty(glob)
+    globflag = 1;
+    % parse glob negation tilde
+    if startsWith(glob,'~')
+        globflag = -1;
+        glob = glob(2:end);
+    end
+    constr = matlab.unittest.constraints.ContainsSubstring(glob);
+    select = matlab.unittest.selectors.HasName(constr);
+    if globflag < 0
+        suiteUseCases = suiteUseCases.selectIf(~select);
+    elseif globflag > 0
+        suiteUseCases = suiteUseCases.selectIf(select);
+    end
 end
 
 % PLACEHOLDER: Here, apply e.g. Tag based filtering

--- a/developer/aa_test.m
+++ b/developer/aa_test.m
@@ -104,12 +104,6 @@ end
 %% Get a list of all tests
 
 % Get Use case tests
-% TODO: Is it acceptable that the tests can only run in 2018b or later? If
-% yes, can then use the next two lines, instead of having to have a
-% pass_inputargs method.
-%param = matlab.unittest.parameters.Parameter.fromData('inputargs', {argParse.Results});
-%suiteUseCases = matlab.unittest.TestSuite.fromClass(?testUseCases, 'ExternalParameters',param);
-% Adapt parameter, in a pre2018b compatible way.
 testUseCases.pass_inputargs('set', argParse.Results);
 suiteUseCases = matlab.unittest.TestSuite.fromClass(?testUseCases);
 

--- a/developer/aa_test.m
+++ b/developer/aa_test.m
@@ -8,7 +8,7 @@ function aa_test(varargin)
 %   == (fullpath) to parameter file. If not specified, aa_test will
 %   use ~/.aa/aap_parameters_user.xml. NB: the parameter file used
 %   for aa_test is slightly different than the standard parameter file.
-%   Briefly, aap.directory_conventions.rawdatadir and 
+%   Briefly, aap.directory_conventions.rawdatadir and
 %   aap.acq_details.root *must* be defined in the parameter file (many
 %   aa users prefer to define these in the analysis script, not the
 %   parameter file) and rawdatadir is interpreted as the *parent*
@@ -18,10 +18,10 @@ function aa_test(varargin)
 %   discussion (including the motivation for these changes).
 %
 % 'glob', glob -
-%   == (limited) glob search string used to restrict which 
+%   == (limited) glob search string used to restrict which
 %   testscripts are run ("limited" in the sense that we only
-%   recognize a string literal and a tilde-negated string literal. 
-%   See example usage below). If not specified, all testscripts 
+%   recognize a string literal and a tilde-negated string literal.
+%   See example usage below). If not specified, all testscripts
 %   are run.
 %
 % 'deleteprevious', deleteprevious -
@@ -32,7 +32,7 @@ function aa_test(varargin)
 %   == true, testing will halt (crash) if any errors, otherwise
 %   testing continues with the next script (default: false)
 %
-% 'wheretoprocess', wheretoprocess- 
+% 'wheretoprocess', wheretoprocess-
 %   == 'localsingle' (default), jobs will run locally in a serial
 %   fashion. Other options include 'parpool' and 'batch' (cluster)
 %
@@ -46,7 +46,7 @@ function aa_test(varargin)
 % example glob usage
 %
 %   aa_test('glob','aatest_ds000114_fmri') - only run aatest_ds000114_fmri.m
-%   aa_test('glob','~ds002737') - run all scripts EXCEPT those with 
+%   aa_test('glob','~ds002737') - run all scripts EXCEPT those with
 %                          "ds002737" in the name (note leading tilde)
 %
 % Notes
@@ -57,7 +57,7 @@ function aa_test(varargin)
 % Expected usage is: 1) do 'aa_test' to run all scripts using
 % defaults, 2) check the log, then 3) run aa_test('glob','foo','haltonerror'
 % ,true) or aa_test('glob','foo','haltonerror',true,'wheretoprocess','qsub')
-% to run the jobs on a cluster and re-run script "foo" that failed in order 
+% to run the jobs on a cluster and re-run script "foo" that failed in order
 % to drop into the debugger.
 %
 % test scripts are assumed to live in $AAHOME/developer/testscripts
@@ -67,7 +67,7 @@ function aa_test(varargin)
 % Revision History
 %
 % 10/2021 [MSJ] - add parameterfile parameter
-% summer/2021 [MSJ] - newish (derived from aatest) 
+% summer/2021 [MSJ] - newish (derived from aatest)
 %
 
 argParse = inputParser;
@@ -79,7 +79,6 @@ argParse.addParameter('parameterfile','', @ischar);
 argParse.parse(varargin{:});
 
 % parse glob negation tilde
-
 globflag = 0;
 glob = argParse.Results.glob;
 if ~isempty(glob)
@@ -91,108 +90,54 @@ if ~isempty(glob)
 end
 
 % logging
-
-if exist(fullfile(pwd,'aa_test.log'),'file') 
+logfile = fullfile(pwd,'aa_test.log');
+if exist(logfile,'file')
     ow = input('aa_test.log exists. Overwrite?(Y/[N])> ','s');
-    if (isempty(ow) || ow == 'N' || ow == 'n'); return; end
-end
-
-fid = fopen(fullfile(pwd,'aa_test.log'),'w');
-
-if (fid < 0)
-    error('Cannot open aa_test.log for writing');
-end
-   
-% get a list of testscripts
-aa = aaClass('nopath','nogreet');
-aadir = aa.Path;
-testdir = fullfile(aadir,'developer','testscripts');
-
-tests = dir(fullfile(testdir,'*.m'));
-testnames = {tests.name};
-
-savedir = pwd;
-cd(testdir);
-
-for fname = testnames
-    if globflag<0 && contains(fname{1},glob); continue; end
-    if globflag>0 && ~contains(fname{1},glob); continue; end
-    fprintf('\n\nRunning %s...\n', fname{1});
-    runit(fname{1}, argParse.Results.parameterfile, argParse.Results.deleteprevious, argParse.Results.haltonerror, argParse.Results.wheretoprocess, fid);
-end
-
-fprintf('------------------\ntests finished.\n')
-cd(savedir);
-fclose(fid);
-
-end
-
-% -------------------------------------------------------------------------
-function runit(scriptname, parameterfile, deleteprevious, haltonerror, wheretoprocess, fid)
-% -------------------------------------------------------------------------
-
-func = str2func(strrep(scriptname,'.m',''));
-
-if  haltonerror
-    
-    % run script normally;
-    % function halts on aa error
-    
-    func(parameterfile, deleteprevious, wheretoprocess);
-    
-    % if encapsulated returns, this script passed
-    
-    fprintf('\npass - %s\n',scriptname);
-    fprintf(fid,'\npass - %s\n',scriptname);
-
-else
-    
-    % run script inside a try-catch;
-    % function flags any error and returns
-    % optionally dropping into qsub_debug
-    
-    try
-        
-        func(parameterfile, deleteprevious, wheretoprocess);
-        fprintf('\npass - %s\n',scriptname);
-        fprintf(fid,'\npass - %s\n',scriptname);
-        
-    catch err
-        
-        fprintf('FAIL - %s\n',scriptname);
-        fprintf(fid,'FAIL - %s\n',scriptname);
-        
-        if strcmp(wheretoprocess,'localsingle')
-            reporterror(scriptname,err);
-        else
-            
-            try
-                aaq_qsub_debug;
-            catch err
-                reporterror(scriptname,err);
-            end
-            
-            % catch cases when aaq_qsub_debug quietly 
-            % returns (e.g., failed to submitjob)
-            
-            keyboard;
-            
-        end
-        
+    if (isempty(ow) || ow == 'N' || ow == 'n')
+        return
+    else
+        % Delete, because do not want to append.
+        delete(logfile)
     end
-
 end
 
+%% Get a list of all tests
+
+% Get Use case tests
+% TODO: Is it acceptable that the tests can only run in 2018b or later? If
+% yes, can then use the next two lines, instead of having to have a
+% pass_inputargs method.
+%param = matlab.unittest.parameters.Parameter.fromData('inputargs', {argParse.Results});
+%suiteUseCases = matlab.unittest.TestSuite.fromClass(?testUseCases, 'ExternalParameters',param);
+% Adapt parameter, in a pre2018b compatible way.
+testUseCases.pass_inputargs('set', argParse.Results);
+suiteUseCases = matlab.unittest.TestSuite.fromClass(?testUseCases);
+
+% PLACEHOLDER: Here, get the non-use case tests
+
+%% Apply glob-based filtering
+constr = matlab.unittest.constraints.ContainsSubstring(glob);
+select = matlab.unittest.selectors.HasName(constr);
+if globflag < 0
+    suiteUseCases = suiteUseCases.selectIf(~select);
+elseif globflag > 0
+    suiteUseCases = suiteUseCases.selectIf(select);
 end
 
-function reporterror(scriptname,err)
-msg = sprintf('%s had an error: %s\n',scriptname,err.message);
-for e = 1:numel(err.stack)
-    % Stop tracking to internal
-    if strfind(err.stack(e).file,'distcomp'), break, end
-    msg = [msg sprintf('<a href="matlab: opentoline(''%s'',%d)">in %s (line %d)</a>\n', ...
-        err.stack(e).file, err.stack(e).line,...
-        err.stack(e).file, err.stack(e).line)];
+% PLACEHOLDER: Here, apply e.g. Tag based filtering
+
+%% Run tests
+runner = matlab.unittest.TestRunner.withTextOutput;
+file_plugin = matlab.unittest.plugins.ToFile(logfile);
+tap_plugin = matlab.unittest.plugins.TAPPlugin.producingOriginalFormat(file_plugin);
+runner.addPlugin(tap_plugin)
+results = runner.run(suiteUseCases);
+
+if argParse.Results.haltonerror
+    % The unittest framework catches errors during tests
+    % Here, throw an error is any test failed. A.o. to notify the
+    % Continuous Integration of failure.
+    assertSuccess(results)
 end
-fprintf(msg)
+
 end

--- a/developer/testscripts/testUseCases.m
+++ b/developer/testscripts/testUseCases.m
@@ -1,0 +1,119 @@
+classdef testUseCases < matlab.unittest.TestCase
+    %TESTUSECASES Tests that represent a full use case.
+
+    properties (Constant)
+        testdir = fileparts(mfilename("fullpath"));
+    end
+
+    properties (TestParameter)
+        testname = testUseCases.get_testscripts()
+        inputargs
+    end
+
+    methods (TestParameterDefinition, Static)
+        function inputargs = initializeProperty()
+            inputargs = testUseCases.pass_inputargs('get');
+        end
+    end
+
+    properties
+        settings = []
+    end
+
+    methods (Test)
+
+        function use_case_test(testCase, testname, inputargs)
+            savedir = pwd;
+            cd(testCase.testdir);
+
+            testUseCases.runit(testname, inputargs.parameterfile, inputargs.deleteprevious, inputargs.haltonerror, inputargs.wheretoprocess);
+
+            cd(savedir);
+        end
+    end
+
+    methods (Static)
+        function testnames = get_testscripts()
+            tests = dir(fullfile(testUseCases.testdir,'aatest_*.m'));
+            testnames = {tests.name};
+        end
+
+        function runit(scriptname, parameterfile, deleteprevious, haltonerror, wheretoprocess)
+
+            func = str2func(strrep(scriptname,'.m',''));
+
+            if  haltonerror
+
+                % run script normally;
+                % function halts on aa error
+
+                func(parameterfile, deleteprevious, wheretoprocess);
+
+                % if encapsulated returns, this script passed
+
+                fprintf('\npass - %s\n',scriptname);
+
+            else
+
+                % run script inside a try-catch;
+                % function flags any error and returns
+                % optionally dropping into qsub_debug
+
+                try
+
+                    func(parameterfile, deleteprevious, wheretoprocess);
+                    fprintf('\npass - %s\n',scriptname);
+
+                catch err
+
+                    fprintf('FAIL - %s\n',scriptname);
+
+                    if strcmp(wheretoprocess,'localsingle')
+                        testUseCases.reporterror(scriptname,err);
+                    else
+
+                        try
+                            aaq_qsub_debug;
+                        catch err
+                            testUseCases.reporterror(scriptname,err);
+                        end
+
+                        % catch cases when aaq_qsub_debug quietly
+                        % returns (e.g., failed to submitjob)
+
+                        keyboard;
+
+                    end
+
+                end
+
+            end
+
+        end
+
+        function reporterror(scriptname,err)
+            msg = sprintf('%s had an error: %s\n',scriptname,err.message);
+            for e = 1:numel(err.stack)
+                % Stop tracking to internal
+                if strfind(err.stack(e).file,'distcomp'), break, end
+                msg = [msg sprintf('<a href="matlab: opentoline(''%s'',%d)">in %s (line %d)</a>\n', ...
+                    err.stack(e).file, err.stack(e).line,...
+                    err.stack(e).file, err.stack(e).line)];
+            end
+            fprintf(msg)
+        end
+
+        function output = pass_inputargs(action, varargin)
+            persistent inputargs
+            output = true;
+            switch action
+                case 'get'
+                    output = {inputargs};
+                case 'set'
+                    inputargs = varargin{1};
+            end
+        end
+
+    end
+end
+

--- a/developer/testscripts/testUseCases.m
+++ b/developer/testscripts/testUseCases.m
@@ -7,26 +7,24 @@ classdef testUseCases < matlab.unittest.TestCase
 
     properties (TestParameter)
         testname = testUseCases.get_testscripts()
-        inputargs
-    end
-
-    methods (TestParameterDefinition, Static)
-        function inputargs = initializeProperty()
-            inputargs = testUseCases.pass_inputargs('get');
-        end
     end
 
     properties
-        settings = []
+        inputargs
+    end
+
+    methods (TestClassSetup)
+        function classSetup(testCase)
+            testCase.inputargs = testUseCases.pass_inputargs('get');
+        end
     end
 
     methods (Test)
-
-        function use_case_test(testCase, testname, inputargs)
+        function use_case_test(testCase, testname)
             savedir = pwd;
             cd(testCase.testdir);
 
-            testUseCases.runit(testname, inputargs.parameterfile, inputargs.deleteprevious, inputargs.haltonerror, inputargs.wheretoprocess);
+            testUseCases.runit(testname, testCase.inputargs.parameterfile, testCase.inputargs.deleteprevious, testCase.inputargs.haltonerror, testCase.inputargs.wheretoprocess);
 
             cd(savedir);
         end
@@ -108,7 +106,7 @@ classdef testUseCases < matlab.unittest.TestCase
             output = true;
             switch action
                 case 'get'
-                    output = {inputargs};
+                    output = inputargs;
                 case 'set'
                     inputargs = varargin{1};
             end


### PR DESCRIPTION
This to enable adding non-use-case tests, which needs more advanced filtering options, while keeping aa_test as the entry point for all testing

For now, the changes are backward compatible with how aa_test could be used before. Only the log file has more info in it now.