### PR TITLE
Fix WIN compatibility issue in aamod_fieldmap2vdm

### DIFF
--- a/aa_modules/aamod_fieldmap2VDM.m
+++ b/aa_modules/aamod_fieldmap2VDM.m
@@ -21,7 +21,7 @@ switch task
         % Fieldmaps
         FM = aas_getfiles_bystream(aap,domain,[subj,sess],'fieldmap');
         for f = 1:size(FM,1)
-            aas_shell(['cp ' squeeze(FM(f,:)) ' ' FMdir]);
+            copyfile(squeeze(FM(f,:)),FMdir);
             FMfn{f} = spm_file(FM(f,:),'path',FMdir);
         end
         switch size(FM,1)


### PR DESCRIPTION
Uses inbuilt matlab function to copy file instead of shell.