### PR TITLE
Use WSL bash for FSL commands if available

### DIFF
--- a/aa_engine/aas_runfslcommand.m
+++ b/aa_engine/aas_runfslcommand.m
@@ -39,6 +39,14 @@ switch (aap.directory_conventions.fslshell)
         end
         cmd = [cmd fslcmd ''''];
         [s, w]=aas_shell(cmd);
+    case 'wsl'
+        cmd=['bash' ' -c -i ''' fslsetup];
+        fslcmd = convertWinPathToWSL(fslcmd);
+        for e = 1:size(ENV,1)
+            cmd = [cmd sprintf('export %s=%s;',ENV{e,1},convertWinPathToWSL(ENV{e,2}))];
+        end
+        cmd = [cmd fslcmd ''''];
+        [s, w]=aas_shell(cmd);
 end
 
 % Display error if there was one

--- a/extrafunctions/convertWinPathToWSL.m
+++ b/extrafunctions/convertWinPathToWSL.m
@@ -1,0 +1,18 @@
+function [outputCmd] = convertWinPathToWSL(inputCmd) % inputCmd
+% This function receives a bash command with windows directories and converts the directories to WSL mount directories.
+mnt_prefix = '/mnt/'; % convert the mount directory to this
+inputCmd = strrep(inputCmd,'\','/'); % change slash direction
+to_be_replaced = {}; % drive letters which need to be replaced
+replace_with = {}; % what to replace with?
+mnt_ind = strfind(inputCmd,':'); % which index to find drive letters?
+for i = 1:size(mnt_ind,2) % loop over the drive letter positions
+    replacement = [mnt_prefix lower(inputCmd(mnt_ind(i)-1))]; % find our replacement
+    replace_with{end+1} = replacement; % set the replacements
+    to_be_replaced{end+1} = [inputCmd(mnt_ind(i)-1) ':']; %
+end
+for i = 1:size(replace_with,2)
+    inputCmd = strrep(inputCmd,to_be_replaced{i},replace_with{i});
+end
+outputCmd = inputCmd;
+
+end


### PR DESCRIPTION
All directories and files which are generated from MATLAB on Windows using AA need to be converted to a WSL compatible version of them before they are run by FSL. Due to this I implemented a function which can convert a Windows directory to it's WSL counterpart. Can you please review this function for me? I guess it may cause issues if the command contains ":" in it. Are there any FSL commands which may have that marker in it? 

A better approach could have been to use Regex, which I don't know very well, but I can check.

I made it so that the paths in the FSL command are converted, so hopefully it will only be directories in the command.

Additionally, at line 46 the second parameter of the export command is converted to WSL compatible version as people may put a windows path to their user parameter file.