### PR TITLE
Fix path logging in aas_shell

### DIFF
--- a/.github/workflows/aa_unittest.yml
+++ b/.github/workflows/aa_unittest.yml
@@ -100,7 +100,7 @@ jobs:
     name: Run all tutorial tests with only a minimal parameter xml / tools install
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/aa_unittest.yml
+++ b/.github/workflows/aa_unittest.yml
@@ -27,7 +27,7 @@ jobs:
     name: Run all tests that do NOT have the Large tag
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/aa_use_case_test.yml
+++ b/.github/workflows/aa_use_case_test.yml
@@ -27,7 +27,7 @@ jobs:
     name: Testing AROMA on fMRI
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -105,7 +105,7 @@ jobs:
     name: Testing SPM DARTEL
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -183,7 +183,7 @@ jobs:
     name: Testing Diffusion (with FSL)
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -261,7 +261,7 @@ jobs:
     name: Testing fMRI
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -341,7 +341,7 @@ jobs:
     name: Testing fMRI frame censoring
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -422,7 +422,7 @@ jobs:
     name: Testing (Freesurfer) Deface and FaceMasking
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -498,7 +498,7 @@ jobs:
     name: Testing the M/EEG (with statistics)
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -579,7 +579,7 @@ jobs:
     name: Testing the M/EEG (with source reconstruction)
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/aa_engine/aas_shell.m
+++ b/aa_engine/aas_shell.m
@@ -34,10 +34,11 @@ if ~hit
 end
 
 %% Run
+log_path = cmd;
 if ispc()
-    cmd = strrep(cmd,'\','\\');
+    log_path = strrep(log_path,'\','\\'); % If Windows, fix the path for cprintf
 end
-if ~quiet, aas_log([],false,['Running: ' prefix cmd]); end
+if ~quiet, aas_log([],false,['Running: ' prefix log_path]); end
 [s,w]=system([prefix cmd]);
 
 if strcmp('shell-init: error', w)
@@ -57,7 +58,7 @@ end
 %% Process error if we're in non-quiet mode OR if we want to stop for errors
 if s && (~quiet || stopforerrors)
     [junk, wenv]=system('/usr/bin/env');
-    aas_log([],false,sprintf('***LINUX ERROR FROM SHELL %s\n***WHILE RUNNING COMMAND\n%s',w,[prefix cmd]));
+    aas_log([],false,sprintf('***LINUX ERROR FROM SHELL %s\n***WHILE RUNNING COMMAND\n%s',w,[prefix log_path]));
     aas_log([],stopforerrors,sprintf('***WITH ENVIRONMENT VARIABLES\n%s',wenv));
     aas_log([],false,'***END, CONTINUING');
 end

--- a/aa_engine/aas_shell.m
+++ b/aa_engine/aas_shell.m
@@ -34,6 +34,9 @@ if ~hit
 end
 
 %% Run
+if ispc()
+    cmd = strrep(cmd,'\','\\');
+end
 if ~quiet, aas_log([],false,['Running: ' prefix cmd]); end
 [s,w]=system([prefix cmd]);
 


### PR DESCRIPTION
Fixes logging in `aas_shell ` due to the backslashes in windows due to them also being an escape character in `cprintf` 