### PR TITLE
DOT additions

### DIFF
--- a/aa_engine/aas_renamestream.m
+++ b/aa_engine/aas_renamestream.m
@@ -11,7 +11,11 @@ if nargin < 5
 end
 
 if strcmp(type,'output')
-    aas_log(aap,false,sprintf('WARNING: Renaming output %s of %s to %s.\n  It might break dependency for the consecuting module(s).\n  Make sure that you know what you are doing!',origstream,stage,newstream));
+    if (isempty(newstream))
+        aas_log(aap,false,sprintf('WARNING: Removing output "%s" of "%s"\n Downstream modules that take "%s" as an input will be passed an alternate source.',origstream,stage,origstream));
+    else
+        aas_log(aap,false,sprintf('WARNING: Renaming output "%s" of "%s" to "%s".\n Downstream modules that take "%s" as an input may also need to rename the stream.',origstream,stage,origstream,newstream));
+    end
 end
 
 %% Locate STAGE

--- a/aa_modules/aamod_QA.m
+++ b/aa_modules/aamod_QA.m
@@ -1,0 +1,257 @@
+function [aap,resp] = aamod_QA(aap, task)
+%
+% generate a QA summary of functional data
+%
+% Change History
+%
+% fall 2023 [MSJ] -- new
+%
+
+resp='';
+
+switch task
+	
+    case 'report'
+        
+    case 'doit'		
+        
+ 
+        nvoxels = aap.tasklist.currenttask.settings.nvoxels;
+        carpetscale = aap.tasklist.currenttask.settings.carpetscale;
+        
+        outlier_filter = aap.tasklist.currenttask.settings.outlier_filter;
+        outlier_threshold = aap.tasklist.currenttask.settings.outlier_threshold;
+           
+        savedir = fullfile(aas_getstudypath(aap),'QA_images');
+        if ~exist(savedir,'dir');mkdir(savedir);end
+        
+        [ ~,subindex_list ] = aas_getN_bydomain(aap,'subject');
+
+        summary_fname = fullfile(aas_getstudypath(aap),'data_summary.txt');
+
+        if exist(summary_fname,'file');delete(summary_fname);end
+
+        fid = fopen(summary_fname,'w'); % plaintext stats summary....
+        
+        if (fid < 0)
+            aas_log(aap, true, 'Cannot open summary file for writing. Halting...');
+        end
+        
+        group_outliers = []; % for group outlier plot...
+
+        for subject_index = subindex_list
+
+            [ ~,all_sess ] = aas_getN_bydomain(aap, 'session', subject_index);
+            session_list = intersect(all_sess, aap.acq_details.selected_sessions);           
+            
+            for session_index = session_list        
+
+                data_instream_struct = aap.tasklist.currenttask.inputstreams(1).stream{1};
+                fname = aas_getfiles_bystream(aap, subject_index, session_index, data_instream_struct.CONTENT); 
+
+                header = spm_vol(fname);
+                data = spm_read_vols(header);
+            
+                [ r,c,s,f ] = size(data);
+                data = reshape(data,r*c*s,f); % nvoxels x nframes
+                                
+                % stats
+
+                nancount = sum(isnan(data(:)));
+                zerocount = sum(data(:)==0);
+                voxsize = diag(header(1).mat);
+                voxsize = voxsize(1:3);
+
+                % swap nan for zeros -- so masking can strip nan
+
+                if (nancount > 0)
+                    data(isnan(data)) = 0;
+                end
+
+                datamax = max(data(:));
+                datamin = min(data(:));
+                
+                % extract voxel subset for processing / plotting
+                
+                selector = floor(linspace(1,r*c*s,nvoxels));
+                data = data(selector,:);
+
+                % we don't have a brainmask, so instead do a
+                % quick and dirty implicit mask: we assume any
+                % identically zero rows are outside of brain
+                % this results in a reasonably good selection
+                % especially if nvoxels is large-ish
+                
+                data = data(all(data~=0,2),:);             
+ 
+                % style points - open window in center of display
+                % (this trick only works if not running cluster)
+               
+                if (strcmp(aap.options.wheretoprocess, 'localsingle'))
+                    h = figure('Position',[0 0 1500 1000], 'Color', [1 1 1],'NumberTitle','off', 'Visible', 'off', 'MenuBar', 'none');
+                    movegui(h, 'center');
+                    set(h, 'Visible', 'on');
+                else
+                    h = figure('Position',[0 0 1500 1000],'Color', [1 1 1], 'NumberTitle','off','MenuBar','none');
+                end
+
+                subplot(3,3,[5 6 8 9]);
+
+                % joy plot
+                
+                surf(data,log(abs(data)));
+                axis tight
+                xlabel('frame','FontSize',18);
+                ylabel('voxel','FontSize',18);
+                set(gca,'FontSize',18);
+                shading interp;
+                colormap gray;
+                cm = colormap;
+                colormap(cm.*cm.*cm); % suppresses midrange
+                view(-25,60);
+
+                % traditional carpet plot for comparison
+
+                subplot(3,3,[4 7]);
+                imagesc(data,[carpetscale(1)*max(data(:)) carpetscale(2)*max(data(:))]);
+                xlabel('frame','FontSize',14);
+                ylabel('voxel','FontSize',14);
+                title('grayplot','FontSize',14);
+
+                % sum over voxels plot and outliers
+
+                subplot(3,3,[1 2 3]);
+
+                sumovervoxels = sum(data,1,'omitnan');
+                plot(sumovervoxels,'k','LineWidth',2);
+                a = axis;
+                hold on;
+                
+                switch outlier_filter
+                    
+                    case 'anymedian'
+                                        
+                        outliers = isoutlier(data,'median',2, 'ThresholdFactor',outlier_threshold);
+                        outliers = any(outliers,1);
+
+                    case 'anymean'
+                        
+                        outliers = isoutlier(data,'mean',2, 'ThresholdFactor',outlier_threshold);
+                        outliers = any(outliers,1);
+                  
+                    case 'mediansum'
+                        
+                        outliers = isoutlier(sumovervoxels,'median', 'ThresholdFactor',outlier_threshold);                  
+                        
+                    case 'meansum'
+                        
+                        outliers = isoutlier(sumovervoxels,'mean', 'ThresholdFactor',outlier_threshold);
+ 
+                    case 'none'
+                        
+                        outliers = [];
+                        
+                end             
+                
+                outlier_index = find(outliers);
+                if ~isempty(outlier_index)
+                    plot(outlier_index,0.5*(a(3)+a(4)),'r+','LineWidth',2,'MarkerSize',12);
+                end
+                axis tight;
+                
+                % include stats in title
+                
+                [~,n,~]=fileparts(fname);
+                n = strrep(n,'_','-');
+                titlestring = [n '   dim: ' num2str([r c s f]) '   voxsize: ' num2str(voxsize') '   max: ' num2str(datamax,3) ' min: ' num2str(datamin,3) '    nan: ' num2str(nancount) ' zeros: ' num2str(zerocount)];
+                title(titlestring,'FontSize',18);
+                
+                if ~isempty(outlier_index)
+                    odescriptor = sprintf('outliers (%s > %g)', outlier_filter, outlier_threshold);
+                    legend({'sum over voxels', odescriptor},'FontSize',16);
+                else
+                    legend('sum over voxels','FontSize',16);
+                end
+                xlabel('frame','FontSize',18);
+                ylabel('intensity','FontSize',18);
+
+                fname_out = fullfile(savedir,sprintf('%s.jpg', n));
+
+                set(h,'Renderer','opengl');
+                set(findall(h,'Type','text'),'FontUnits','normalized');
+                h.InvertHardcopy = 'off'; % otherwise matlab changes our nice black bg to white
+                print(h, '-djpeg', '-r150', fname_out);
+                
+                close(h);
+                              
+                % collect outliers for group outlier plot
+                                
+                if (isempty(group_outliers))
+                    group_outliers(1,:) = outliers;
+                else
+                    % must protect against unequal number-of-frames
+                    [~,ncols] = size(group_outliers);
+                    if (ncols < length(outliers))
+                        % this will zero extend ALL rows of group_outliers
+                        % to new width so we can add this data to bottom
+                        group_outliers(1,length(outliers)) = 0;
+                    end
+                    if (ncols > length(outliers))
+                        % this will extend current outliers to fit
+                        % group_outliers (we assume frame(1) are aligned)
+                        outliers(ncols) = 0;
+                    end
+                    group_outliers(end+1,:) = outliers;
+                end
+                    
+                % add stats to summary file
+                
+                fprintf(fid,'%s    outliers: %d\n', titlestring, sum(outliers));
+              
+            end % session
+           
+        end % subject
+             
+        fclose(fid); % summary_fname
+        
+        % group outlier plot
+        % this is useful for detecting correlated artifacts across subjects
+        
+        % get a little better appearance if we size the window to fit data
+        
+        [nrows,ncols] = size(group_outliers);
+
+        if (strcmp(aap.options.wheretoprocess, 'localsingle'))
+            h2 = figure('Position',[0 0 6*ncols 20*nrows], 'Color', [1 1 1],'NumberTitle','off', 'Visible', 'off', 'MenuBar', 'none');
+            movegui(h2, 'center');
+            set(h2, 'Visible', 'on');
+        else
+            h2 = figure('Position',[0 0 6*ncols 20*nrows],'Color', [1 1 1], 'NumberTitle','off','MenuBar','none');
+        end
+             
+        group_outliers(end+1,end+1) = 0; % pcolor needs a dummy row/col
+        pcolor(group_outliers);
+        title('Outliers','FontSize',16);
+        xlabel('frame','FontSize',14);
+        ylabel('subject','FontSize',14);
+        colormap gray;
+        
+        fname_out = fullfile(aas_getstudypath(aap),'group_outliers.jpg');
+        set(h2,'Renderer','opengl');
+        set(findall(h2,'Type','text'),'FontUnits','normalized');
+        h2.InvertHardcopy = 'off';
+        print(h2, '-djpeg', '-r150', fname_out);
+        close(h2);
+        
+        aap = aas_desc_outputs(aap, 'data_summary', summary_fname);
+
+        % done!
+               
+    case 'checkrequirements'
+        
+    otherwise
+        
+        aas_log(aap,true,sprintf('Unknown task %s',task));
+        
+end % switch
+end % function

--- a/aa_modules/aamod_QA.xml
+++ b/aa_modules/aamod_QA.xml
@@ -21,7 +21,15 @@
             
             <carpetscale>[-2 0.8]</carpetscale>
             
-            <!-- outlier flagging -->
+            <!-- outlier flagging ; flag frame as an outlier if: -->
+            
+            <!-- anymedian = any voxel in the frame exceeds threshold x MAD from the median -->
+            <!-- anymean   = any voxel in the frame exceeds threshold x SD from the mean -->
+            <!-- mediansum = sum across voxels in the frame exceeds threshold x MAD from the median -->
+            <!-- meansum   = sum across voxels in the frame exceeds threshold x SD from the mean -->
+            <!-- none      = apply no outlier detection -->
+
+            <!-- (MAD = median absolute deviation; SD = standard deviation) -->
 
             <outlier_filter options='anymedian|anymean|mediansum|meansum|none'>meansum</outlier_filter>
             <outlier_threshold>3</outlier_threshold>

--- a/aa_modules/aamod_QA.xml
+++ b/aa_modules/aamod_QA.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aap>
+    <tasklist>
+        <currenttask domain='study' desc='make QA summary of functional data' modality='MRI'>
+            
+            <!-- generate a collection of epi QA maps -->
+            
+            <qsub>
+                <timeBase>1</timeBase>
+                <memoryBase>1</memoryBase>
+            </qsub>
+            
+            <!-- number of voxels to include in QA plots -->
+            
+            <!-- actual number will probably be less, as any NaN or -->
+            <!-- zero timeseries are asssumed outside brain and skipped -->
+            
+            <nvoxels>1000</nvoxels>
+            
+            <!-- min/max color scaling for the carpet plot -->
+            
+            <carpetscale>[-2 0.8]</carpetscale>
+            
+            <!-- outlier flagging -->
+
+            <outlier_filter options='anymedian|anymean|mediansum|meansum|none'>meansum</outlier_filter>
+            <outlier_threshold>3</outlier_threshold>
+          
+            <inputstreams>
+                <stream isrenameable='1'>epi</stream>
+            </inputstreams>
+            
+            <outputstreams>
+                <stream>QA_summary</stream>
+            </outputstreams>
+            
+        </currenttask>
+    </tasklist>
+</aap>

--- a/aa_modules/aamod_dot_fromnifti.xml
+++ b/aa_modules/aamod_dot_fromnifti.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aap>
+    <tasklist>
+        <currenttask domain='session' mfile_alias='aamod_epifromnifti' desc='generate dot stream from nifti' modality='MRI'>
+     
+            <!-- this module generates an dot stream from a nifti file -->
+            <!-- it reuses aamod_epifromnifti.m rather than writing a dedicated -->
+            <!-- aamod_dot_fromnifti.m which would largely be identical code -->
+            
+            <!-- the difference is we create "dot" and "functional_header" outstreams -->
+            <!-- (rather than "epi" and "epi_dicom_header"); we are gradually modifying -->
+            <!-- modules that hardcode epi and epi_dicom_header to use renameable streams -->
+            <!-- (and perhaps adding an aamod_*_dot aliased header) if that functionality -->
+            <!-- is useful outside of epi processing (ex: aamod_firstlevel_model) -->
+                        
+            <qsub>
+                <timeBase>0.2</timeBase>
+                <memoryBase>0.2</memoryBase>
+            </qsub>
+            
+            <permanenceofoutput>1</permanenceofoutput>          
+            
+            <numdummies></numdummies>
+            
+            <inputstreams>
+            </inputstreams>
+            
+            <!-- do not change the order of these streams -->
+            <!-- (required for renameability) -->
+            
+            <outputstreams>
+                <stream>dot</stream>
+                <stream>dummyscans</stream>
+                <stream>dot_header</stream>
+            </outputstreams>
+            
+        </currenttask>
+    </tasklist>
+</aap>
+

--- a/aa_modules/aamod_dot_fromnifti.xml
+++ b/aa_modules/aamod_dot_fromnifti.xml
@@ -6,13 +6,7 @@
             <!-- this module generates an dot stream from a nifti file -->
             <!-- it reuses aamod_epifromnifti.m rather than writing a dedicated -->
             <!-- aamod_dot_fromnifti.m which would largely be identical code -->
-            
-            <!-- the difference is we create "dot" and "functional_header" outstreams -->
-            <!-- (rather than "epi" and "epi_dicom_header"); we are gradually modifying -->
-            <!-- modules that hardcode epi and epi_dicom_header to use renameable streams -->
-            <!-- (and perhaps adding an aamod_*_dot aliased header) if that functionality -->
-            <!-- is useful outside of epi processing (ex: aamod_firstlevel_model) -->
-                        
+                                
             <qsub>
                 <timeBase>0.2</timeBase>
                 <memoryBase>0.2</memoryBase>
@@ -24,10 +18,7 @@
             
             <inputstreams>
             </inputstreams>
-            
-            <!-- do not change the order of these streams -->
-            <!-- (required for renameability) -->
-            
+                       
             <outputstreams>
                 <stream>dot</stream>
                 <stream>dummyscans</stream>

--- a/aa_modules/aamod_epifromnifti.m
+++ b/aa_modules/aamod_epifromnifti.m
@@ -145,13 +145,27 @@ switch task
             if iscell(V), V = cell2mat(V); end
             spm_file_merge(char({V(numdummies+1:end).fname}),finalepis,0,DICOMHEADERS{1}.volumeTR);
         end
+        
+        
         % And describe outputs
+
+        % new: output streams are renameable so that other modalities
+        % (e.g., dot) can reuse aamod_epifromnifti w/ just a header alias
+        
+        outputstreams = aas_getstreams(aap,'output'); 
+        
+        ostream_01 = outputstreams{1};
+        ostream_02 = outputstreams{2};
+        ostream_03 = outputstreams{3};
+         
         if comp, rmdir(fullfile(sesspth,'temp'),'s'); end
-        aap=aas_desc_outputs(aap,subj,sess,'epi',finalepis);
-        aap = aas_desc_outputs(aap,subj,sess,'dummyscans',dummylist);
-        dcmhdrfn = fullfile(sesspth,'dicom_headers.mat');
+        aap=aas_desc_outputs(aap,subj,sess, ostream_01,finalepis);
+        aap = aas_desc_outputs(aap,subj,sess,ostream_02,dummylist);
+        
+        dcmhdrfn = fullfile(sesspth,'functional_header.mat');
         save(dcmhdrfn,'DICOMHEADERS');
-        aap = aas_desc_outputs(aap,subj,sess,'epi_dicom_header',dcmhdrfn);
+        aap = aas_desc_outputs(aap,subj,sess,ostream_03,dcmhdrfn);
+
         
     case 'checkrequirements'
         

--- a/aa_modules/aamod_epifromnifti.m
+++ b/aa_modules/aamod_epifromnifti.m
@@ -17,9 +17,9 @@ switch task
         %% Select
         series = horzcat(aap.acq_details.subjects(subj).seriesnumbers{:});
         if ~iscell(series) ... 
-                || (~isstruct(series{sess}) ... % hdr+fname
-                && ~ischar(series{sess}) ... % fname
-                && ~iscell(series{sess})) % fname (4D)
+                || (~isstruct(series{1}) ... % hdr+fname
+                && ~ischar(series{1}) ... % fname
+                && ~iscell(series{1})) % fname (4D)
             aas_log(aap,true,['ERROR: Was expecting list of struct(s) of fname+hdr or fname in cell array\n' help('aas_addsubject')]);            
         end
         series = series{sess};
@@ -145,18 +145,28 @@ switch task
             if iscell(V), V = cell2mat(V); end
             spm_file_merge(char({V(numdummies+1:end).fname}),finalepis,0,DICOMHEADERS{1}.volumeTR);
         end
-        
-        
-        % And describe outputs
+              
+        % Describe outputs
 
         % new: output streams are renameable so that other modalities
         % (e.g., dot) can reuse aamod_epifromnifti w/ just a header alias
         
+        % we assume the first output streamname defines the modality;
+        % the remaining outstream names are derived from it
+        
         outputstreams = aas_getstreams(aap,'output'); 
         
         ostream_01 = outputstreams{1};
-        ostream_02 = outputstreams{2};
-        ostream_03 = outputstreams{3};
+       
+        ostream_02 = 'dummyscans';
+        
+        if strcmp(ostream_01,'epi')
+            ostream_03 = 'epi_dicom_header';
+        elseif strcmp(ostream_01,'dot')
+            ostream_03 = 'dot_header';
+        else
+            ostream_03 = 'functional_header';
+        end      
          
         if comp, rmdir(fullfile(sesspth,'temp'),'s'); end
         aap=aas_desc_outputs(aap,subj,sess, ostream_01,finalepis);

--- a/aa_modules/aamod_epifromnifti.xml
+++ b/aa_modules/aamod_epifromnifti.xml
@@ -15,10 +15,13 @@
             <inputstreams>
             </inputstreams>
             
+            <!-- NB: if you modify this header, do not change the order -->
+            <!-- of the output streams(required for renameability) -->
+            
             <outputstreams>
-                <stream>epi</stream>
-                <stream>dummyscans</stream>
-                <stream>epi_dicom_header</stream>
+                <stream isrenameable='1'>epi</stream>
+                <stream isrenameable='1'>dummyscans</stream>
+                <stream isrenameable='1'>epi_dicom_header</stream>
             </outputstreams>
             
         </currenttask>

--- a/aa_modules/aamod_epifromnifti.xml
+++ b/aa_modules/aamod_epifromnifti.xml
@@ -14,14 +14,11 @@
             
             <inputstreams>
             </inputstreams>
-            
-            <!-- NB: if you modify this header, do not change the order -->
-            <!-- of the output streams(required for renameability) -->
-            
+                       
             <outputstreams>
-                <stream isrenameable='1'>epi</stream>
-                <stream isrenameable='1'>dummyscans</stream>
-                <stream isrenameable='1'>epi_dicom_header</stream>
+                <stream>epi</stream>
+                <stream>dummyscans</stream>
+                <stream>epi_dicom_header</stream>
             </outputstreams>
             
         </currenttask>

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -380,9 +380,13 @@ switch task
         
         %% Adjust outstream?
                 
-        % the residual streamname is the last listed in the outputs
-        outputstreams = aas_getstreams(aap,'output');        
-        residualstreamname = outputstreams{end};
+        % if we don't write residuals, we need to delete the residual output stream
+        % the residual streamname is the same as the input streamname (e.g, "epi" in => "epi" out as residuals)
+        % however, we can't assume the name = "epi" because the stream is renameable
+        % instead, we assume the input is the first input stream
+        
+        inputstreams = aas_getstreams(aap,'input');        
+        residualstreamname = inputstreams{1};
         if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),residualstreamname))
             aap = aas_renamestream(aap,aap.tasklist.currenttask.name,residualstreamname,[],'output');
             aas_log(aap,false,sprintf('REMOVED: %s output stream: %s', aap.tasklist.currenttask.name,residualstreamname));

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -243,8 +243,10 @@ switch task
         aap=aas_desc_outputs(aap,subj,'firstlevel_betas',betafns);
         
         if isfield(aap.tasklist.currenttask.settings,'writeresiduals') && ~isempty(aap.tasklist.currenttask.settings.writeresiduals)
+            inputstreams = aas_getstreams(aap,'input');        
+            residualstreamname = inputstreams{1};
             for s = subjSessionI
-                aap=aas_desc_outputs(aap,subj,s,'epi',residuals{s});
+                aap=aas_desc_outputs(aap,subj,s,residualstreamname,residuals{s});
             end
         end
 
@@ -383,7 +385,7 @@ switch task
         % if we don't write residuals, we need to delete the residual output stream
         % the residual streamname is the same as the input streamname (e.g, "epi" in => "epi" out as residuals)
         % however, we can't assume the name = "epi" because the stream is renameable
-        % instead, we assume the input is the first input stream
+        % instead, we assume the name is the first input stream
         
         inputstreams = aas_getstreams(aap,'input');        
         residualstreamname = inputstreams{1};

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -378,11 +378,16 @@ switch task
             end
         end
         
-        %% Adjust outstream
-        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),'epi'))
-            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,'epi',[],'output');
-            aas_log(aap,false,sprintf('REMOVED: %s output stream: epi', aap.tasklist.currenttask.name'));
+        %% Adjust outstream?
+                
+        % the residual streamname is the last listed in the outputs
+        outputstreams = aas_getstreams(aap,'output');        
+        residualstreamname = outputstreams{end};
+        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),residualstreamname))
+            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,residualstreamname,[],'output');
+            aas_log(aap,false,sprintf('REMOVED: %s output stream: %s', aap.tasklist.currenttask.name,residualstreamname));
         end
+
         
     otherwise
         aas_log(aap,1,sprintf('Unknown task %s',task));

--- a/aa_modules/aamod_firstlevel_model_dot.xml
+++ b/aa_modules/aamod_firstlevel_model_dot.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aap>
+    <tasklist>
+        <currenttask domain='subject' mfile_alias='aamod_firstlevel_model' desc='First level model for dot' modality='MRI'>
+            
+            <!-- this header is a copy of aamod_firstlevel_model.xml -->
+            <!-- w/ modifications to use dot rather than epi data -->
+            
+            <qsub>
+                <timeBase>0.5</timeBase>
+                <memoryBase>0.25</memoryBase>
+            </qsub>
+            
+            <permanenceofoutput>3</permanenceofoutput>
+            
+            <!-- no firstlevelmasking here any more - use aap.spm.defaults.mask.thresh=-inf;-->
+            <!-- includemovementpars 0=none; 1=realignment parms -->
+            <includemovementpars>1</includemovementpars>
+            
+            <!-- if the stream 'listspikes' is present, should we include deltas for each spike? -->
+            <includespikes>0</includespikes>
+            
+            <!-- if the stream 'gd_results' is present, should we include the PCA noise regressors? -->
+            <includeGLMDNregs>1</includeGLMDNregs>
+            
+            <!-- Movement matrix, deciding which derivatives/orders of the movement parameters are used! -->
+            <moveMat>[1 0 0; 0 0 0]</moveMat>
+            
+            <!-- include Compartment Regressors derived from aamod_compSignal 
+            By default filled with [2 3] [i.e. WM and CSF signals] if you have run aamoc_compSignal-->
+            <compRegs>[2 3]</compRegs>
+            
+            <!-- high pass filter in seconds -->
+            <highpassfilter>128</highpassfilter>
+            
+            <!-- First level model masking
+			0 - none
+			1 - implicit
+			otherwise (0-1) - fraction threshold
+			-->
+            <firstlevelmasking>1</firstlevelmasking>
+            
+            <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
+            <autocorrelation>AR(1)</autocorrelation>
+            
+            <!-- enable/disable orthogoanlisation (only for SPM12 and above) -->
+            <orthogonalisation>1</orthogonalisation>
+            
+            <!-- write residuals (only for SPM12 and above) 
+            (empty) - do not write
+            0       - corrected for no effect
+            NaN     - corrected for all effect
+            >0      - corrected for a given contrast
+            -->
+            <writeresiduals></writeresiduals>
+            
+			<allowemptymodel>0</allowemptymodel>
+			
+            <!-- TR, if we wish to define it within the first level model 
+            If empty, we try to find from DICOM headers... -->
+            <TR></TR>
+            
+            <model>
+                <subject></subject>
+                <session></session>
+                <event>
+                    <name></name>
+                    <ons></ons>
+                    <dur></dur>
+                </event>
+            </model>
+            
+            <modelC>
+                <subject></subject>
+                <session></session>
+                <covariate>
+                    <name></name>
+                    <vector></vector>
+                    <HRF></HRF>
+                    <interest></interest>
+                </covariate>
+            </modelC>
+            
+            <xBF>
+                <T>17</T>
+                <UNITS>secs</UNITS>
+                <Volterra>1</Volterra>
+                <name>hrf</name>
+                <length>32</length>
+                <order>1</order>
+                <T0></T0>
+                <bf></bf>
+            </xBF>
+            
+            <!-- changed epi to hdddot and epi_dicom_header to dot_header -->
+            <!-- removed sliceorder stream -->
+            
+            <inputstreams>
+                <stream >dot</stream>
+				<stream isessential='0'>ppi</stream>
+                <stream isessential='0'>listspikes</stream>
+                <stream isessential='0'>dot_header</stream>
+                <stream isessential='0'>realignment_parameter</stream>                
+				<stream isessential='0'>compSignal</stream>
+				<stream isessential='0'>gd_results</stream>
+            </inputstreams>
+            
+            <!-- dot outstream used for residuals and will be removed -->
+            <!-- if 'writeresiduals' is not set (which is usually the case) -->
+            
+            <!-- dot must appear last in the outputstreams list -->
+            <!-- otherwise it will break stream renaming -->
+            
+            <outputstreams>
+                <stream>firstlevel_spm</stream>
+                <stream>firstlevel_betas</stream>
+                <stream>firstlevel_brainmask</stream>
+                <stream isrenameable='1'>dot</stream>
+            </outputstreams>
+            
+        </currenttask>
+    </tasklist>
+</aap>
+

--- a/aa_modules/aamod_firstlevel_model_dot.xml
+++ b/aa_modules/aamod_firstlevel_model_dot.xml
@@ -97,12 +97,12 @@
             
             <inputstreams>
                 <stream >dot</stream>
-				<stream isessential='0'>ppi</stream>
+		<stream isessential='0'>ppi</stream>
                 <stream isessential='0'>listspikes</stream>
                 <stream isessential='0'>dot_header</stream>
                 <stream isessential='0'>realignment_parameter</stream>                
-				<stream isessential='0'>compSignal</stream>
-				<stream isessential='0'>gd_results</stream>
+		<stream isessential='0'>compSignal</stream>
+		<stream isessential='0'>gd_results</stream>
             </inputstreams>
             
             <!-- dot outstream used for residuals and will be removed -->

--- a/aa_modules/aamod_intersubject_correlation.m
+++ b/aa_modules/aamod_intersubject_correlation.m
@@ -18,28 +18,28 @@ switch task
         
         % put some xml settings into local variables for better code readability
 
-        subtract_global_signal = aap.tasklist.currenttask.settings.subtract_global_signal;
-        convert_r_to_z = aap.tasklist.currenttask.settings.convert_r_to_z;       
-        verbose = aap.tasklist.currenttask.settings.verbose;
-        save_individual_maps = aap.tasklist.currenttask.settings.save_individual_maps;
+        subtract_global_signal = aas_getsetting(aap,'subtract_global_signal');
+        convert_r_to_z = aas_getsetting(aap,'convert_r_to_z');
+        verbose = aas_getsetting(aap,'verbose');
+        save_individual_maps = aas_getsetting(aap,'save_individual_maps');
         
-        rmap_threshold = aap.tasklist.currenttask.settings.rmap_threshold;
-        show_only_positive_values = aap.tasklist.currenttask.settings.show_only_positive_values; 
-        show_only_negative_values = aap.tasklist.currenttask.settings.show_only_negative_values; 
+        rmap_threshold = aas_getsetting(aap,'rmap_threshold');
+        show_only_positive_values = aas_getsetting(aap,'show_only_positive_values'); 
+        show_only_negative_values = aas_getsetting(aap,'show_only_negative_values'); 
         
-        maximum_number_of_sessions = aap.tasklist.currenttask.settings.maximum_number_of_sessions;
+        maximum_number_of_sessions = aas_getsetting(aap,'maximum_number_of_sessions');
 
         if (save_individual_maps == true)
             mkdir(aas_getstudypath(aap),fullfile('pairwise_maps'));
             individual_map_fnames = {}; % cell array of fnames for desc
         end
         
-        generate_summary_correlation_matrix = aap.tasklist.currenttask.settings.generate_summary_correlation_matrix;
+        generate_summary_correlation_matrix = aas_getsetting(aap,'generate_summary_correlation_matrix');
       
-        outlier_filter = aap.tasklist.currenttask.settings.outlier_filter;
-        outlier_threshold = aap.tasklist.currenttask.settings.outlier_threshold;
+        outlier_filter = aas_getsetting(aap,'outlier_filter');
+        outlier_threshold = aas_getsetting(aap,'outlier_threshold');
         if strcmp(outlier_filter,'none');exclude_outliers=false;else;exclude_outliers=true;end
-                             
+                              
         % ****************     
         % DATA
         % ****************
@@ -63,12 +63,9 @@ switch task
             end
 
             for session_index = session_list
+                                
+                temp = aas_getfiles_bystream(aap, subject_index, session_index, aas_getstreams(aap,'input', 2));
                 
-                % switch to renameable input stream
-
-                data_instream_struct = aap.tasklist.currenttask.inputstreams(1).stream{2};
-                temp = aas_getfiles_bystream(aap, subject_index, session_index, data_instream_struct.CONTENT); 
-
                 fnames{end+1} = temp;
                 FID{end+1} = sprintf('SUB%02dSESS%02d',subject_index, session_index);
 
@@ -128,12 +125,11 @@ switch task
         mask_has_changed = false; 
         
         % 2) optional instream mask
-
-        mask_inputstream_struct = aap.tasklist.currenttask.inputstreams(1).stream{1};
-
-        if (aas_stream_has_contents(aap, mask_inputstream_struct.CONTENT))
-
-            instream_mask_fname = aas_getfiles_bystream(aap, mask_inputstream_struct.CONTENT);
+                  
+        if (aas_stream_has_contents(aap,aas_getstreams(aap,'input',1))) 
+                
+            instream_mask_fname = aas_getfiles_bystream(aap, aas_getstreams(aap,'input',1));
+               
             instream_mask_header = spm_vol(instream_mask_fname);
 
             if (~isequal(instream_mask_header.dim,mask_header.dim)|| ~isequal(instream_mask_header.mat,mask_header.mat))

--- a/aa_modules/aamod_intersubject_correlation.xml
+++ b/aa_modules/aamod_intersubject_correlation.xml
@@ -3,8 +3,10 @@
     <tasklist>
         <currenttask domain='study' desc='intersubject correlation' modality='MRI'>
             
-            <!-- compute correlation maps of all subject epis considered pairwise -->
+            <!-- compute correlation maps of all subject functional maps considered pairwise -->
             <!-- see: Hasson et al. Science 303:1634-1640 (2004) -->
+
+            <!-- default inputstreamname = "epi" -->
             
             <!-- NB: "n" subjects = n(n-1)/2 pairings, which can be quite large -->
             
@@ -94,7 +96,12 @@
             <!-- (computed using Fisher Z transform) -->
             
             <convert_r_to_z>0</convert_r_to_z> 
-          
+            
+            <!-- outlier exclusion -->
+
+            <outlier_filter options='anymedian|anymean|mediansum|meansum|none'>meansum</outlier_filter>
+            <outlier_threshold>3</outlier_threshold>
+        
             <!-- echo progress and diagnostics to command window? -->
             
             <verbose>1</verbose>
@@ -103,7 +110,7 @@
            
             <inputstreams>
                 <stream isessential='0' isrenameable='1'>groupbrainmask</stream>
-                <stream>epi</stream>
+                <stream isrenameable='1'>epi</stream>
             </inputstreams>
             
             <outputstreams>

--- a/aa_modules/aamod_intersubject_correlation.xml
+++ b/aa_modules/aamod_intersubject_correlation.xml
@@ -98,9 +98,10 @@
             <convert_r_to_z>0</convert_r_to_z> 
             
             <!-- outlier exclusion -->
+            <!-- see aamod_QA for description of options -->
 
-            <outlier_filter options='anymedian|anymean|mediansum|meansum|none'>meansum</outlier_filter>
-            <outlier_threshold>3</outlier_threshold>
+            <outlier_filter options='none|anymedian|anymean|mediansum|meansum|GVTD'>none</outlier_filter>
+            <outlier_threshold></outlier_threshold>
         
             <!-- echo progress and diagnostics to command window? -->
             


### PR DESCRIPTION
Hello all,

This PR includes code that begins to properly integrate DOT processing into aa. The changes are mostly making streams renameable so existing modules that work with epi data can be used with DOT data. This is a long-term project; more modules will be modified as we eventually open more aa functionality to DOT. If you're not working with DOT, these changes should be transparent.

There's also aamod_dot_fromnifti that creates a bona fide "dot" stream rather than repurposing "epi" (hence the need for the renameable streams mentioned above) which is how we were previously working with DOT data. Future PR will add aamod_dot_fromsnirf, aamod_dot_fromndot, and so on as time permits.

Also included is a new lightweight QA module that generates a combined carpet, joy, and outlier plot for functional data along with a summary of basic file metrics (dimensions, voxel size, number of NaN, etc). It will work on any 4D data, has no prerequisite streams (the current carpet plot module needs FD and DVARS and segmentation) and saves jpegs that can be loaded using aa_jpeg_crawler and visually reviewed. We have discovered the joy plots are good for our DOT data, which often contain artifacts that are hard to see in a carpet plot.

Finally, aamod_intersubject_correlation has been modified to optionally exclude outliers. These can artificially inflate r values if not removed



![sub-23-ses-01-task-movie-bold](https://github.com/automaticanalysis/automaticanalysis/assets/25826038/890f8b76-17ee-4975-b701-2389ec6c2dd2)



