### PR TITLE
Fix version check in xml_write.m

### DIFF
--- a/external/XML_IO_Tools/xml_write.m
+++ b/external/XML_IO_Tools/xml_write.m
@@ -86,7 +86,7 @@ function DOMnode = xml_write(filename, tree, RootName, Pref)
 
 %% Check Matlab Version
 v = ver('MATLAB');
-v = str2double(regexp(v.Version, '\d.\d','match','once'));
+v = str2double(regexp(v.Version, '\d+.\d','match','once'));
 if (v<7)
   error('Your MATLAB version is too old. You need version 7.0 or newer.');
 end

--- a/external/XML_IO_Tools/xml_write.m
+++ b/external/XML_IO_Tools/xml_write.m
@@ -86,7 +86,7 @@ function DOMnode = xml_write(filename, tree, RootName, Pref)
 
 %% Check Matlab Version
 v = ver('MATLAB');
-v = str2double(regexp(v.Version, '\d+.\d','match','once'));
+v = str2double(regexp(v.Version, '\d+.\d+','match','once'));
 if (v<7)
   error('Your MATLAB version is too old. You need version 7.0 or newer.');
 end


### PR DESCRIPTION
Fixes an error caused by the miscalculation of the version when using MATLAB version 2023b.

The toolbox was last updated in 2010 so I don't think the developer is interested in fixing the bug.