### PR TITLE
Fall 2024 bugfixes

### DIFF
--- a/aa_engine/aas_processBIDS.m
+++ b/aa_engine/aas_processBIDS.m
@@ -662,13 +662,20 @@ end
 
 function LIST = tsvread(fname)
 filestr = fileread(fname);
+% this is counting lines based on the number of newlines (char(10))
+% this is error-prone because some files may have a terminal newline
+% and some may not. We can improve this by stripping any trailing
+% whitespace then adding one...
 nLines = sum(double(filestr)==10);
+filestr = strtrim(filestr);
+nLines = sum(double(filestr)==10)+1;
 LIST = textscan(filestr,'%s','Delimiter','\t');
 LIST = LIST{1};
 % protect against extraneous whitespace in the tsv:
 LIST = LIST(~cellfun(@isempty,LIST));
 LIST = reshape(LIST,[],nLines)';
 end
+
 
 function str = strrep_multi(str, old, new)
 for i = 1:numel(old)

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -100,6 +100,8 @@ switch task
                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
                         'PHYS',temp.PPI.Y,0,1);
 
+
+
                 end % if ~isempty(defCov{1})...       
             end % if aas_stream_has_contents(aap,'session',[subj,sess],'ppi')...
         end % for sess = subjSessionI...
@@ -143,6 +145,7 @@ switch task
         %%%%%%%%%%%%%%%%%%%
         
         SPM.xY.P = allfiles;
+
         if aap.tasklist.currenttask.settings.firstlevelmasking && aap.tasklist.currenttask.settings.firstlevelmasking < 1
             spm_get_defaults('mask.thresh',aap.tasklist.currenttask.settings.firstlevelmasking);
         end
@@ -253,10 +256,8 @@ switch task
         aap=aas_desc_outputs(aap,subj,'firstlevel_betas',betafns);
         
         if isfield(aap.tasklist.currenttask.settings,'writeresiduals') && ~isempty(aap.tasklist.currenttask.settings.writeresiduals)
-            inputstreams = aas_getstreams(aap,'input');        
-            residualstreamname = inputstreams{1};
             for s = subjSessionI
-                aap=aas_desc_outputs(aap,subj,s,residualstreamname,residuals{s});
+                aap=aas_desc_outputs(aap,subj,s,'epi',residuals{s});
             end
         end
 
@@ -390,20 +391,11 @@ switch task
             end
         end
         
-        %% Adjust outstream?
-                
-        % if we don't write residuals, we need to delete the residual output stream
-        % the residual streamname is the same as the input streamname (e.g, "epi" in => "epi" out as residuals)
-        % however, we can't assume the name = "epi" because the stream is renameable
-        % instead, we assume the name is the first input stream
-        
-        inputstreams = aas_getstreams(aap,'input');        
-        residualstreamname = inputstreams{1};
-        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),residualstreamname))
-            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,residualstreamname,[],'output');
-            aas_log(aap,false,sprintf('REMOVED: %s output stream: %s', aap.tasklist.currenttask.name,residualstreamname));
+        %% Adjust outstream
+        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),'epi'))
+            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,'epi',[],'output');
+            aas_log(aap,false,sprintf('REMOVED: %s output stream: epi', aap.tasklist.currenttask.name'));
         end
-
         
     otherwise
         aas_log(aap,1,sprintf('Unknown task %s',task));

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -195,8 +195,9 @@ switch task
         % (SPM will intersect this with any implicit masking...)
         
         if aas_stream_has_contents(aap, subj,'explicitmask')
-           explicitmaskfname = aas_getfiles_bystream(aap, subj,'explicitmask');
-           aas_log(aap,false,sprintf('Adding explicit mask %s', explicitmaskfname));
+            % this will look for mask at subject level, then
+            % try study level is a subject level mask not found
+           explicitmaskfname = aas_getfiles_bystream_multilevel(aap, 'subject', subj, 'explicitmask');
            SPMdes.xM.VM = spm_vol(explicitmaskfname);
         end
 

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -88,24 +88,6 @@ switch task
                     % providing flexible PPI modeling options to those
                     % who need them.
                
-%                     load(aas_getfiles_bystream(aap,subj,sess,'ppi'));
-%
-%                     [phys, psych] = strtok(PPI.name,'x('); psych =
-%                     psych(3:end-1);  % this assumes PPI.name is something
-%                     like foox(blerg) - maybe this used to be true but we
-%                     now allow user to name the PPI so we can't rely on it
-% 
-%                     aap = aas_addcovariate(aap,modname,...
-%                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
-%                         'PPI',PPI.ppi,0,1);
-%                     aap = aas_addcovariate(aap,modname,...
-%                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
-%                         ['Psych_' psych],PPI.P,0,1);
-%                     aap = aas_addcovariate(aap,modname,...
-%                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
-%                         ['Phys_' phys],PPI.Y,0,1);
-%  
-
                     temp = load(aas_getfiles_bystream(aap,subj,sess,'ppi'));
 
                     aap = aas_addcovariate(aap,modname,...
@@ -117,8 +99,6 @@ switch task
                     aap = aas_addcovariate(aap,modname,...
                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
                         'PHYS',temp.PPI.Y,0,1);
-
-
 
                 end % if ~isempty(defCov{1})...       
             end % if aas_stream_has_contents(aap,'session',[subj,sess],'ppi')...
@@ -163,7 +143,6 @@ switch task
         %%%%%%%%%%%%%%%%%%%
         
         SPM.xY.P = allfiles;
-
         if aap.tasklist.currenttask.settings.firstlevelmasking && aap.tasklist.currenttask.settings.firstlevelmasking < 1
             spm_get_defaults('mask.thresh',aap.tasklist.currenttask.settings.firstlevelmasking);
         end
@@ -274,8 +253,10 @@ switch task
         aap=aas_desc_outputs(aap,subj,'firstlevel_betas',betafns);
         
         if isfield(aap.tasklist.currenttask.settings,'writeresiduals') && ~isempty(aap.tasklist.currenttask.settings.writeresiduals)
+            inputstreams = aas_getstreams(aap,'input');        
+            residualstreamname = inputstreams{1};
             for s = subjSessionI
-                aap=aas_desc_outputs(aap,subj,s,'epi',residuals{s});
+                aap=aas_desc_outputs(aap,subj,s,residualstreamname,residuals{s});
             end
         end
 
@@ -409,11 +390,20 @@ switch task
             end
         end
         
-        %% Adjust outstream
-        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),'epi'))
-            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,'epi',[],'output');
-            aas_log(aap,false,sprintf('REMOVED: %s output stream: epi', aap.tasklist.currenttask.name'));
+        %% Adjust outstream?
+                
+        % if we don't write residuals, we need to delete the residual output stream
+        % the residual streamname is the same as the input streamname (e.g, "epi" in => "epi" out as residuals)
+        % however, we can't assume the name = "epi" because the stream is renameable
+        % instead, we assume the name is the first input stream
+        
+        inputstreams = aas_getstreams(aap,'input');        
+        residualstreamname = inputstreams{1};
+        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),residualstreamname))
+            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,residualstreamname,[],'output');
+            aas_log(aap,false,sprintf('REMOVED: %s output stream: %s', aap.tasklist.currenttask.name,residualstreamname));
         end
+
         
     otherwise
         aas_log(aap,1,sprintf('Unknown task %s',task));

--- a/aa_modules/aamod_firstlevel_model.m
+++ b/aa_modules/aamod_firstlevel_model.m
@@ -100,8 +100,6 @@ switch task
                         basename(aas_getsubjpath(aap,subj)),aap.acq_details.sessions(sess).name,...
                         'PHYS',temp.PPI.Y,0,1);
 
-
-
                 end % if ~isempty(defCov{1})...       
             end % if aas_stream_has_contents(aap,'session',[subj,sess],'ppi')...
         end % for sess = subjSessionI...
@@ -145,7 +143,6 @@ switch task
         %%%%%%%%%%%%%%%%%%%
         
         SPM.xY.P = allfiles;
-
         if aap.tasklist.currenttask.settings.firstlevelmasking && aap.tasklist.currenttask.settings.firstlevelmasking < 1
             spm_get_defaults('mask.thresh',aap.tasklist.currenttask.settings.firstlevelmasking);
         end
@@ -195,13 +192,12 @@ switch task
         end
 
         % add explicit mask if one is specified
-        if ~isempty(aap.tasklist.currenttask.settings.explicitmaskfname)
-            if exist(aap.tasklist.currenttask.settings.explicitmaskfname)
-                aas_log(aap,false,sprintf('Adding explicit mask %s', aap.tasklist.currenttask.settings.explicitmaskfname));
-                SPMdes.xM.VM = spm_vol(aap.tasklist.currenttask.settings.explicitmaskfname);
-            else
-                aas_log(aap,true,sprintf('Cannot find explicit mask %s', aap.tasklist.currenttask.settings.explicitmaskfname));
-            end
+        % (SPM will intersect this with any implicit masking...)
+        
+        if aas_stream_has_contents(aap, subj,'explicitmask')
+           explicitmaskfname = aas_getfiles_bystream(aap, subj,'explicitmask');
+           aas_log(aap,false,sprintf('Adding explicit mask %s', explicitmaskfname));
+           SPMdes.xM.VM = spm_vol(explicitmaskfname);
         end
 
         if (strcmp(aap.tasklist.currenttask.settings.autocorrelation,'wls'))
@@ -256,8 +252,10 @@ switch task
         aap=aas_desc_outputs(aap,subj,'firstlevel_betas',betafns);
         
         if isfield(aap.tasklist.currenttask.settings,'writeresiduals') && ~isempty(aap.tasklist.currenttask.settings.writeresiduals)
+            inputstreams = aas_getstreams(aap,'input');        
+            residualstreamname = inputstreams{1};
             for s = subjSessionI
-                aap=aas_desc_outputs(aap,subj,s,'epi',residuals{s});
+                aap=aas_desc_outputs(aap,subj,s,residualstreamname,residuals{s});
             end
         end
 
@@ -391,11 +389,20 @@ switch task
             end
         end
         
-        %% Adjust outstream
-        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),'epi'))
-            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,'epi',[],'output');
-            aas_log(aap,false,sprintf('REMOVED: %s output stream: epi', aap.tasklist.currenttask.name'));
+        %% Adjust outstream?
+                
+        % if we don't write residuals, we need to delete the residual output stream
+        % the residual streamname is the same as the input streamname (e.g, "epi" in => "epi" out as residuals)
+        % however, we can't assume the name = "epi" because the stream is renameable
+        % instead, we assume the name is the first input stream
+        
+        inputstreams = aas_getstreams(aap,'input');        
+        residualstreamname = inputstreams{1};
+        if isempty(aas_getsetting(aap,'writeresiduals')) && any(strcmp(aas_getstreams(aap,'output'),residualstreamname))
+            aap = aas_renamestream(aap,aap.tasklist.currenttask.name,residualstreamname,[],'output');
+            aas_log(aap,false,sprintf('REMOVED: %s output stream: %s', aap.tasklist.currenttask.name,residualstreamname));
         end
+
         
     otherwise
         aas_log(aap,1,sprintf('Unknown task %s',task));

--- a/aa_modules/aamod_firstlevel_model.xml
+++ b/aa_modules/aamod_firstlevel_model.xml
@@ -37,10 +37,6 @@
 			-->
             <firstlevelmasking>1</firstlevelmasking>
 
-            <!-- optional explicit mask (fullpath to .nii file) applied to all subjects -->
-            <!-- SPM will combine (intersect) this with firstlevelmasking option -->
-            <explicitmaskfname></explicitmaskfname>
-
             <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
             <autocorrelation>AR(1)</autocorrelation>
             
@@ -95,7 +91,7 @@
             
             <inputstreams>
                 <stream isrenameable='1' ismodified='0'>epi</stream>
-				<stream isessential='0'>ppi</stream>
+                <stream isessential='0'>ppi</stream>
                 <stream isessential='0'>listspikes</stream>
                 <stream isessential='0'>epi_dicom_header</stream>
                 <stream isessential='0'>sliceorder</stream>
@@ -103,6 +99,7 @@
                 <stream isessential='0'>compSignal</stream>
                 <stream isessential='0'>gd_results</stream>
                 <stream isessential='0'>physreg</stream>
+                <stream isessential='0'>explicitmask</stream>
             </inputstreams>
             
             <outputstreams>

--- a/aa_modules/aamod_firstlevel_model.xml
+++ b/aa_modules/aamod_firstlevel_model.xml
@@ -36,7 +36,11 @@
 			otherwise (0-1) - fraction threshold
 			-->
             <firstlevelmasking>1</firstlevelmasking>
-            
+
+            <!-- optional explicit mask (fullpath to .nii file) applied to all subjects -->
+            <!-- SPM will combine (intersect) this with firstlevelmasking option -->
+            <explicitmaskfname></explicitmaskfname>
+
             <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
             <autocorrelation>AR(1)</autocorrelation>
             
@@ -96,8 +100,9 @@
                 <stream isessential='0'>epi_dicom_header</stream>
                 <stream isessential='0'>sliceorder</stream>
                 <stream isessential='0'>realignment_parameter</stream>                
-				<stream isessential='0'>compSignal</stream>
-				<stream isessential='0'>gd_results</stream>
+                <stream isessential='0'>compSignal</stream>
+                <stream isessential='0'>gd_results</stream>
+                <stream isessential='0'>physreg</stream>
             </inputstreams>
             
             <outputstreams>

--- a/aa_modules/aamod_firstlevel_model.xml
+++ b/aa_modules/aamod_firstlevel_model.xml
@@ -35,7 +35,14 @@
 			1 - implicit
 			otherwise (0-1) - fraction threshold
 			-->
+
             <firstlevelmasking>1</firstlevelmasking>
+
+            <!-- note you can also provide an explicit mask using the explicitmask -->
+            <!-- input stream (SPM will take the intersection w/ firstlevelmasking) -->
+            <!-- the explicit mask can be subject-level (one for each subject) -->
+            <!-- or study level (one mask applied to all subjects); specify -->
+            <!-- the explicit mask using aas_addinitialstream -->
 
             <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
             <autocorrelation>AR(1)</autocorrelation>

--- a/aa_modules/aamod_firstlevel_model_dot.xml
+++ b/aa_modules/aamod_firstlevel_model_dot.xml
@@ -39,6 +39,10 @@
 			otherwise (0-1) - fraction threshold
 			-->
             <firstlevelmasking>1</firstlevelmasking>
+
+            <!-- optional explicit mask (fullpath to .nii file) applied to all subjects -->
+            <!-- SPM will combine (intersect) this with firstlevelmasking option -->
+            <explicitmaskfname></explicitmaskfname>
             
             <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
             <autocorrelation>AR(1)</autocorrelation>
@@ -54,7 +58,7 @@
             -->
             <writeresiduals></writeresiduals>
             
-			<allowemptymodel>0</allowemptymodel>
+            <allowemptymodel>0</allowemptymodel>
 			
             <!-- TR, if we wish to define it within the first level model 
             If empty, we try to find from DICOM headers... -->
@@ -103,6 +107,7 @@
                 <stream isessential='0'>realignment_parameter</stream>                
 		<stream isessential='0'>compSignal</stream>
 		<stream isessential='0'>gd_results</stream>
+                <stream isessential='0'>physreg</stream>
             </inputstreams>
             
             <!-- dot outstream used for residuals and will be removed -->

--- a/aa_modules/aamod_firstlevel_model_dot.xml
+++ b/aa_modules/aamod_firstlevel_model_dot.xml
@@ -40,10 +40,6 @@
 			-->
             <firstlevelmasking>1</firstlevelmasking>
 
-            <!-- optional explicit mask (fullpath to .nii file) applied to all subjects -->
-            <!-- SPM will combine (intersect) this with firstlevelmasking option -->
-            <explicitmaskfname></explicitmaskfname>
-            
             <!-- 'None' or 'AR(1)' or 'wls' (must have rWLS toolbox installed) -->
             <autocorrelation>AR(1)</autocorrelation>
             
@@ -101,13 +97,14 @@
             
             <inputstreams>
                 <stream >dot</stream>
-		<stream isessential='0'>ppi</stream>
+                <stream isessential='0'>ppi</stream>
                 <stream isessential='0'>listspikes</stream>
                 <stream isessential='0'>dot_header</stream>
                 <stream isessential='0'>realignment_parameter</stream>                
 		<stream isessential='0'>compSignal</stream>
 		<stream isessential='0'>gd_results</stream>
                 <stream isessential='0'>physreg</stream>
+                <stream isessential='0'>explicitmask</stream>
             </inputstreams>
             
             <!-- dot outstream used for residuals and will be removed -->

--- a/aa_modules/aamod_joyplot.m
+++ b/aa_modules/aamod_joyplot.m
@@ -1,0 +1,275 @@
+function [aap,resp] = aamod_joyplot(aap, task)
+%
+% generate a joyplot of functional data
+%
+% Change History
+%
+% fall 2024 [MSJ] -- renamed (aamod_joyplot)
+% fall 2023 [MSJ] -- new
+%
+
+resp='';
+
+switch task
+	
+    case 'report'
+        
+    case 'doit'		  
+        
+        nvoxels = aas_getsetting(aap,'nvoxels');
+        carpetscale = aas_getsetting(aap,'carpetscale');
+
+        outlier_filter = aas_getsetting(aap,'outlier_filter');
+        outlier_threshold = aas_getsetting(aap,'outlier_threshold');
+       
+        imagedir = fullfile(aas_getstudypath(aap),'QA_images');
+        if ~exist(imagedir,'dir');mkdir(imagedir);end
+        
+        datadir = fullfile(aas_getstudypath(aap),'QA_data');
+        if ~exist(datadir,'dir');mkdir(datadir);end
+        
+        [ ~,subindex_list ] = aas_getN_bydomain(aap,'subject');
+
+        summary_fname = fullfile(aas_getstudypath(aap),'data_summary.txt');
+
+        if exist(summary_fname,'file');delete(summary_fname);end
+
+        fid = fopen(summary_fname,'w'); % plaintext stats summary....
+        
+        if (fid < 0)
+            aas_log(aap, true, 'Cannot open summary file for writing. Halting...');
+        end
+        
+        group_outliers = []; % accumulate outliers for group outlier plot...
+
+        for subject_index = subindex_list
+
+            [ ~,all_sess ] = aas_getN_bydomain(aap, 'session', subject_index);
+            session_list = intersect(all_sess, aap.acq_details.selected_sessions);           
+            
+            for session_index = session_list        
+
+                fname = aas_getfiles_bystream(aap, subject_index, session_index, aas_getstreams(aap,'input',1)); 
+        
+                header = spm_vol(fname);
+                data = spm_read_vols(header);
+            
+                [ r,c,s,f ] = size(data);
+                data = reshape(data,r*c*s,f); % nvoxels x nframes
+                                
+                % stats
+
+                nancount = sum(isnan(data(:)));
+                zerocount = sum(data(:)==0);
+                voxsize = diag(header(1).mat);
+                voxsize = voxsize(1:3);
+
+                % swap nan for zeros -- so masking can strip nan
+
+                if (nancount > 0)
+                    data(isnan(data)) = 0;
+                end
+
+                datamax = max(data(:));
+                datamin = min(data(:));
+                
+                % extract voxel subset for processing / plotting
+                
+                selector = floor(linspace(1,r*c*s,nvoxels));
+                data = data(selector,:);
+
+                % we don't have a brainmask, so instead do a
+                % quick and dirty implicit mask: we assume any
+                % identically zero rows are outside of brain
+                % this results in a reasonably good selection
+                % especially if nvoxels is large-ish
+                
+                data = data(all(data~=0,2),:);  
+  
+                % removing DC offset improves joy and carpet plot color scaling...
+                % (and has no effect on outlier identification)
+                
+                data = data - mean(data(:));
+ 
+                % style points - open window in center of display
+                % (this trick only works if running localsingle)
+               
+                if (strcmp(aap.options.wheretoprocess, 'localsingle'))
+                    h = figure('Position',[0 0 1500 1000], 'Color', [1 1 1],'NumberTitle','off', 'Visible', 'off', 'MenuBar', 'none');
+                    movegui(h, 'center');
+                    set(h, 'Visible', 'on');
+                else
+                    h = figure('Position',[0 0 1500 1000],'Color', [1 1 1], 'NumberTitle','off','MenuBar','none');
+                end
+
+                subplot(3,3,[5 6 8 9]);
+
+                % joy plot
+                
+                surf(data,log(abs(data)));
+                axis tight
+                xlabel('frame','FontSize',18);
+                ylabel('voxel','FontSize',18);
+                set(gca,'FontSize',18);
+                shading interp;
+                colormap gray;
+                cm = colormap;
+                colormap(cm.*cm.*cm); % suppresses midrange
+                view(-25,60);
+
+                % traditional carpet plot for comparison
+
+                subplot(3,3,[4 7]);
+                imagesc(data,[carpetscale(1)*max(data(:)) carpetscale(2)*max(data(:))]);
+                xlabel('frame','FontSize',14);
+                ylabel('voxel','FontSize',14);
+                title('grayplot','FontSize',14);
+
+                % average over voxels plot and outliers
+
+                subplot(3,3,[1 2 3]);
+
+                summary = mean(data,1,'omitnan');
+                plot(summary,'k','LineWidth',2);
+                a = axis;
+                hold on;
+                
+                switch outlier_filter
+                    
+                    case 'anymedian'
+                                        
+                        outliers = isoutlier(data,'median',2, 'ThresholdFactor',outlier_threshold);
+                        outliers = any(outliers,1);
+
+                    case 'anymean'
+                        
+                        outliers = isoutlier(data,'mean',2, 'ThresholdFactor',outlier_threshold);
+                        outliers = any(outliers,1);
+                  
+                    case 'mediansum'
+                        
+                        outliers = isoutlier(summary,'median', 'ThresholdFactor',outlier_threshold);                  
+                        
+                    case 'meansum'
+                        
+                        outliers = isoutlier(summary,'mean', 'ThresholdFactor',outlier_threshold);
+ 
+                    case 'none'
+                        
+                        outliers = [];
+                        
+                end             
+                
+                outlier_index = find(outliers);
+                if ~isempty(outlier_index)
+                    plot(outlier_index,0.5*(a(3)+a(4)),'r+','LineWidth',2,'MarkerSize',12);
+                end
+                axis tight;
+                
+                % include stats in title
+                
+                ID = sprintf('%s-%s',aas_getsubjname(aap,subject_index),aas_getsessname(aap,session_index));
+
+                titlestring = [strrep(ID,'_','-') '   dim: ' num2str([r c s f]) '   voxsize: ' num2str(voxsize')  '  min: ' num2str(datamin,3)  '  max: ' num2str(datamax,3)  '  nan: ' num2str(nancount) ' zeros: ' num2str(zerocount)];
+                title(titlestring,'FontSize',18);
+                
+                if ~isempty(outlier_index)
+                    odescriptor = sprintf('outliers (%s > %g)', outlier_filter, outlier_threshold);
+                    legend({'global signal', odescriptor},'FontSize',16);
+                else
+                    legend('global signal','FontSize',16);
+                end
+                xlabel('frame','FontSize',18);
+                ylabel('intensity','FontSize',18);
+
+                fname_out = fullfile(imagedir,sprintf('%s.jpg', strrep(ID,'-','_')));
+
+                set(h,'Renderer','opengl');
+                set(findall(h,'Type','text'),'FontUnits','normalized');
+                h.InvertHardcopy = 'off'; % otherwise matlab changes our nice black bg to white
+                print(h, '-djpeg', '-r150', fname_out);
+                
+                close(h);
+                
+                % save the summary data
+
+                fname_out = fullfile(datadir,sprintf('%s.mat', strrep(ID,'-','_')));
+                save(fname_out,'data','summary');
+                            
+                % collect outliers for group outlier plot
+                                
+                if (isempty(group_outliers))
+                    group_outliers(1,:) = outliers;
+                else
+                    % must protect against unequal number-of-frames
+                    [~,ncols] = size(group_outliers);
+                    if (ncols < length(outliers))
+                        % this will zero extend ALL rows of group_outliers
+                        % to new width so we can add this data to bottom
+                        group_outliers(1,length(outliers)) = 0;
+                    end
+                    if (ncols > length(outliers))
+                        % this will extend current outliers to fit
+                        % group_outliers (we assume frame(1) are aligned)
+                        outliers(ncols) = 0;
+                    end
+                    group_outliers(end+1,:) = outliers;
+                end
+                    
+                % add stats to summary file
+                
+                fprintf(fid,'%s    outliers: %d\n', titlestring, sum(outliers));
+              
+            end % session
+           
+        end % subject
+             
+        fclose(fid); % summary_fname
+        
+        % group outlier plot
+        % this is useful for detecting correlated artifacts across subjects
+        
+        % get a little better appearance if we size the window to fit data
+               
+        [nrows,ncols] = size(group_outliers);
+        
+        % don't need to make a group plot if there's just one subject
+ 
+        if (nrows > 1)
+
+            if (strcmp(aap.options.wheretoprocess, 'localsingle'))
+                h2 = figure('Position',[0 0 5*ncols 50+20*nrows], 'Color', [1 1 1],'NumberTitle','off', 'Visible', 'off', 'MenuBar', 'none');
+                movegui(h2, 'center');
+                set(h2, 'Visible', 'on');
+            else
+                h2 = figure('Position',[0 0 5*ncols 50+20*nrows],'Color', [1 1 1], 'NumberTitle','off','MenuBar','none');
+            end
+
+            group_outliers(end+1,end+1) = 0; % pcolor needs a terminal dummy row/col
+            pcolor(group_outliers);
+            title('Outliers','FontSize',16);
+            xlabel('frame','FontSize',14);
+            ylabel('subject','FontSize',14);
+            colormap gray;
+
+            fname_out = fullfile(aas_getstudypath(aap),'group_outliers.jpg');
+            set(h2,'Renderer','opengl');
+            set(findall(h2,'Type','text'),'FontUnits','normalized');
+            h2.InvertHardcopy = 'off';
+            print(h2, '-djpeg', '-r150', fname_out);
+            close(h2);
+        
+        end
+        
+        aap = aas_desc_outputs(aap, 'data_summary', summary_fname);
+
+        % done!
+               
+    case 'checkrequirements'
+        
+    otherwise
+        
+        aas_log(aap,true,sprintf('Unknown task %s',task));
+        
+end % switch
+end % function

--- a/aa_modules/aamod_joyplot.xml
+++ b/aa_modules/aamod_joyplot.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aap>
+    <tasklist>
+        <currenttask domain='study' desc='generate joyplot of functional data' modality='MRI'>
+            
+              
+            <!-- number of voxels to include in plots -->
+            
+            <!-- actual number will probably be less, as any NaN or -->
+            <!-- zero timeseries are asssumed outside brain and skipped -->
+            
+            <nvoxels>1000</nvoxels>
+            
+            <!-- min/max color scaling for the carpet plot -->
+            
+            <carpetscale>[-2 0.8]</carpetscale>
+            
+            <!-- outlier flagging ; flag frame as an outlier if: -->
+            
+            <!-- anymedian = any voxel in the frame exceeds threshold x MAD from the median -->
+            <!-- anymean   = any voxel in the frame exceeds threshold x SD from the mean -->
+            <!-- mediansum = sum across voxels in the frame exceeds threshold x MAD from the median -->
+            <!-- meansum   = sum across voxels in the frame exceeds threshold x SD from the mean -->
+            <!-- none      = apply no outlier detection -->
+
+            <!-- (MAD = median absolute deviation; SD = standard deviation) -->
+
+            <outlier_filter options='anymedian|anymean|mediansum|meansum|none'>meansum</outlier_filter>
+            <outlier_threshold>3</outlier_threshold>
+          
+            <inputstreams>
+                <stream isrenameable='1'>epi</stream>
+            </inputstreams>
+            
+            <outputstreams>
+                <stream>QA_summary</stream>
+            </outputstreams>
+            
+        </currenttask>
+    </tasklist>
+</aap>

--- a/aa_modules/aamod_secondlevel_randomise.m
+++ b/aa_modules/aamod_secondlevel_randomise.m
@@ -26,6 +26,7 @@ function [ aap,resp ] = aamod_secondlevel_randomise(aap,task)
 %
 % CHANGE HISTORY
 %
+% 10/2024 [MSJ] swap "sleep" for "pause" and { } for "extractfield"
 % 08/2023 [MSJ] skip F contrasts
 % 06/2021 [MSJ] attempt to implement sensible FSL file naming
 % 06/2019 [MSJ] Modified to run one or two sample ttest w/ covariates
@@ -76,7 +77,7 @@ switch task
                 master_subject_list = { master_subject_list{:}, temp{:} };
             end   
         else
-            master_subject_list = extractfield(aap.acq_details.subjects,'subjname');
+        master_subject_list = { aap.acq_details.subjects.subjname };
         end
         
         nsub = numel(master_subject_list);
@@ -271,25 +272,23 @@ switch task
             pause(1);  % feels necessary to let bg process launch...
         end
               
-        % block here until all outfiles exist
+        % block until all the contrast directories are populated
 
         for cindex = 1:numel(dirnames)
 
             dirname = dirnames{cindex};
 
-            % block until all the contrast directories are populated
-
             temp = dir(fullfile(pth, sprintf('%s/*tstat*.%s', dirname, fsl_file_extension)));
 
             while (numel(temp) == 0)
-                unix('sleep 60s');
+                pause(60);
                 temp = dir(fullfile(pth, sprintf('%s/*tstat*.%s', dirname, fsl_file_extension)));
              end
 
         end
         
-        % pause here to let filesystem catch-up
-        pause(1);
+        % one final block here in case filesystem needs to catch-up
+        pause(60);
 
         % clean up temp files; Note we don't delete design.mat and 
         % design.con in two-group test -- leave for verification
@@ -402,7 +401,7 @@ if (isempty(group_two_subjectIDs))
                 
     end
 
-    % this only time this if branch should be entered is one group + one
+    % the only time this if branch should be entered is one group + one
     % covariate (one group no covariates uses simplified fsl call (see line
     % ~139 and two groups uses branch below). As such, an eye(2) contrast
     % isn't useful here -- if the covariate is nuisance, we just want [1 0]

--- a/extrafunctions/washu_surfacerender.m
+++ b/extrafunctions/washu_surfacerender.m
@@ -55,6 +55,7 @@ function washu_surfacerender(img, cmap, cfg, fname)
 
 % CHANGE HISTORY
 %
+% 10/2024 [MSJ] - fix scaling for passed colormap
 % 06/2021 [MSJ] - cleanup
 % 05/2020 [MSJ] - new; modified from jp_spm8_surfacerender
 %                 add missing helper functions
@@ -295,7 +296,6 @@ cdat = zeros(size(v,2),3);
 maxv = max(abs(v)); % largest positive or negative value
 minv = -1 * maxv;
 
-
 if any(v(:))
   if strcmp(cfg.colorscale, 'symmetrical')
     cdat = squeeze(ind2rgb(floor( (v(:)-minv)/(2*maxv) * size(col,1)), col));
@@ -303,8 +303,7 @@ if any(v(:))
   elseif ~isempty(cfg.colorscale)
     cmin = cfg.colorscale(1);
     cmax = cfg.colorscale(2);
-    
-    cdat = squeeze(ind2rgb(floor( (v(:)-cmin)/(cmax) * size(col,1)), col));
+    cdat = squeeze(ind2rgb(floor( (v(:)-cmin)/(cmax-cmin) * size(col,1)), col));
     fprintf('Color scale from %g to %g.\n', cmin, cmax);    
   else
     if size(col,1)>3


### PR DESCRIPTION
Hello all,

This PR has a few minor bugfixes and an extension to aamod_firstlevel_model:

1) aas_processBIDS -- fixed a tsvread bug where it will calculate a wrong line count if the terminal newline character is missing in the tsv file.

2) washu_surfacerender -- fixed a bug in explicit color scaling.

3) aamod_secondlevel_randomise -- Apple changed their unix "sleep" syntax so I changed file blocking to use Matlab "pause" instead.

4) aamod_firstlevel_model -- added an explicit mask option we need for our work using aa to analyze HDDOT data. HDDOT doesn't provide a structural image, so you need to pass a mask based on the optode array field of view (or use SPM implicit masking, which can be unreliable). Also, I reinstated the physreg stream to the header which somehow got deleted. Note this file is committed twice in the PR -- the first time I used the wrong version and just adding a new commit seemed less error-prone than attempting clever git-fu to delete the first commit...)

5) Finally, I added a new module: aamod_joyplot. This creates a "joyplot" of functional data which we find provides better QA information than a greyplot (aka carpetplot). Perhaps others might find it useful.  Here's an example:

![sample_joyplot](https://github.com/user-attachments/assets/7776eb5e-02ae-4ec7-bf7c-8b9cd9cb5959)

The module also plots all outliers in the dataset, which we find helpful to identify artifacts that are correlated across subjects.
